### PR TITLE
Created Better async Event Wrapping

### DIFF
--- a/src/Crash.Handlers/InternalEvents/CrashObjectEventArgs.cs
+++ b/src/Crash.Handlers/InternalEvents/CrashObjectEventArgs.cs
@@ -1,4 +1,6 @@
-﻿using Rhino.DocObjects;
+﻿using Crash.Common.Document;
+
+using Rhino.DocObjects;
 using Rhino.Geometry;
 
 namespace Crash.Handlers.InternalEvents
@@ -8,6 +10,9 @@ namespace Crash.Handlers.InternalEvents
 	{
 		/// <summary>Change Id</summary>
 		public readonly Guid ChangeId;
+
+		/// <summary>The Crash Doc this Object comes from</summary>
+		public readonly CrashDoc Doc;
 
 		/// <summary>The Event Geometry</summary>
 		public readonly GeometryBase Geometry;
@@ -19,8 +24,10 @@ namespace Crash.Handlers.InternalEvents
 		public readonly bool UnDelete;
 
 		/// <summary>Constructor mainly for tests</summary>
-		public CrashObjectEventArgs(GeometryBase geometry, Guid rhinoId, Guid changeId = default, bool unDelete = false)
+		public CrashObjectEventArgs(CrashDoc crashDoc, GeometryBase geometry, Guid rhinoId, Guid changeId = default,
+			bool unDelete = false)
 		{
+			Doc = crashDoc;
 			ChangeId = changeId;
 			RhinoId = rhinoId;
 			Geometry = geometry;
@@ -28,8 +35,9 @@ namespace Crash.Handlers.InternalEvents
 		}
 
 		/// <summary>Default Constructor</summary>
-		public CrashObjectEventArgs(RhinoObject rhinoObject, Guid changeId = default, bool unDelete = false)
-			: this(rhinoObject.Geometry, rhinoObject.Id, changeId, unDelete)
+		public CrashObjectEventArgs(CrashDoc crashDoc, RhinoObject rhinoObject, Guid changeId = default,
+			bool unDelete = false)
+			: this(crashDoc, rhinoObject.Geometry, rhinoObject.Id, changeId, unDelete)
 		{
 		}
 	}

--- a/src/Crash.Handlers/InternalEvents/CrashObjectEventArgs.cs
+++ b/src/Crash.Handlers/InternalEvents/CrashObjectEventArgs.cs
@@ -15,17 +15,21 @@ namespace Crash.Handlers.InternalEvents
 		/// <summary>The Event Rhino Id</summary>
 		public readonly Guid RhinoId;
 
+		/// <summary>UnDelete flag</summary>
+		public readonly bool UnDelete;
+
 		/// <summary>Constructor mainly for tests</summary>
-		public CrashObjectEventArgs(GeometryBase geometry, Guid rhinoId, Guid changeId = default)
+		public CrashObjectEventArgs(GeometryBase geometry, Guid rhinoId, Guid changeId = default, bool unDelete = false)
 		{
 			ChangeId = changeId;
 			RhinoId = rhinoId;
 			Geometry = geometry;
+			UnDelete = unDelete;
 		}
 
 		/// <summary>Default Constructor</summary>
-		public CrashObjectEventArgs(RhinoObject rhinoObject, Guid changeId = default)
-			: this(rhinoObject.Geometry, rhinoObject.Id, changeId)
+		public CrashObjectEventArgs(RhinoObject rhinoObject, Guid changeId = default, bool unDelete = false)
+			: this(rhinoObject.Geometry, rhinoObject.Id, changeId, unDelete)
 		{
 		}
 	}

--- a/src/Crash.Handlers/InternalEvents/CrashSelectionEventArgs.cs
+++ b/src/Crash.Handlers/InternalEvents/CrashSelectionEventArgs.cs
@@ -1,4 +1,6 @@
-﻿namespace Crash.Handlers.InternalEvents
+﻿using Crash.Common.Document;
+
+namespace Crash.Handlers.InternalEvents
 {
 	/// <summary>Wraps the RhinoSelection and Deselection Events</summary>
 	public sealed class CrashSelectionEventArgs : EventArgs
@@ -6,27 +8,33 @@
 		/// <summary>Related Event Objets</summary>
 		public readonly IEnumerable<CrashObject> CrashObjects;
 
+		/// <summary>The Crash Doc of these Args</summary>
+		public readonly CrashDoc Doc;
+
 		/// <summary>Was this a Selection Event or Deselection Event</summary>
 		public readonly bool Selected;
 
 		/// <summary>Singular Selection/Deselection Event Constructor</summary>
-		private CrashSelectionEventArgs(bool selected,
+		private CrashSelectionEventArgs(CrashDoc crashDoc, bool selected,
 			IEnumerable<CrashObject> crashObjects)
 		{
+			Doc = crashDoc;
 			CrashObjects = crashObjects;
 			Selected = selected;
 		}
 
 		/// <summary>Creates a new DeSelection Event for One item</summary>
-		public static CrashSelectionEventArgs CreateSelectionEvent(IEnumerable<CrashObject> crashObjects)
+		public static CrashSelectionEventArgs CreateSelectionEvent(CrashDoc crashDoc,
+			IEnumerable<CrashObject> crashObjects)
 		{
-			return new CrashSelectionEventArgs(true, crashObjects);
+			return new CrashSelectionEventArgs(crashDoc, true, crashObjects);
 		}
 
 		/// <summary>Creates a new Selection Event for One item</summary>
-		public static CrashSelectionEventArgs CreateDeSelectionEvent(IEnumerable<CrashObject> crashObjects)
+		public static CrashSelectionEventArgs CreateDeSelectionEvent(CrashDoc crashDoc,
+			IEnumerable<CrashObject> crashObjects)
 		{
-			return new CrashSelectionEventArgs(false, crashObjects);
+			return new CrashSelectionEventArgs(crashDoc, false, crashObjects);
 		}
 	}
 }

--- a/src/Crash.Handlers/InternalEvents/CrashTransformEventArgs.cs
+++ b/src/Crash.Handlers/InternalEvents/CrashTransformEventArgs.cs
@@ -1,10 +1,14 @@
-﻿using Crash.Geometry;
+﻿using Crash.Common.Document;
+using Crash.Geometry;
 
 namespace Crash.Handlers.InternalEvents
 {
 	/// <summary>Wraps Rhino Transform Event Args</summary>
 	public sealed class CrashTransformEventArgs : EventArgs
 	{
+		/// <summary>The Crash Doc of these Args</summary>
+		public readonly CrashDoc Doc;
+
 		/// <summary>The affected Objects</summary>
 		public readonly IEnumerable<CrashObject> Objects;
 
@@ -15,10 +19,11 @@ namespace Crash.Handlers.InternalEvents
 		public readonly CTransform Transform;
 
 		/// <summary>Default Constructor</summary>
-		internal CrashTransformEventArgs(CTransform transform,
+		internal CrashTransformEventArgs(CrashDoc crashDoc, CTransform transform,
 			IEnumerable<CrashObject> objects,
 			bool objectsWillBeCopied)
 		{
+			Doc = crashDoc;
 			Transform = transform;
 			Objects = objects;
 			ObjectsWillBeCopied = objectsWillBeCopied;

--- a/src/Crash.Handlers/InternalEvents/CrashUpdateArgs.cs
+++ b/src/Crash.Handlers/InternalEvents/CrashUpdateArgs.cs
@@ -1,0 +1,16 @@
+﻿namespace Crash.Handlers.InternalEvents
+{
+	/// <summary>Wraps Rhino Object change Event Args</summary>
+	public sealed class CrashUpdateArgs
+	{
+		public readonly CrashObject CrashObject;
+
+		public readonly Dictionary<string, string> Updates;
+
+		public CrashUpdateArgs(CrashObject crashObject, Dictionary<string, string> updates)
+		{
+			CrashObject = crashObject;
+			Updates = updates;
+		}
+	}
+}

--- a/src/Crash.Handlers/InternalEvents/CrashUpdateArgs.cs
+++ b/src/Crash.Handlers/InternalEvents/CrashUpdateArgs.cs
@@ -1,14 +1,25 @@
-﻿namespace Crash.Handlers.InternalEvents
+﻿using Crash.Common.Document;
+
+namespace Crash.Handlers.InternalEvents
 {
 	/// <summary>Wraps Rhino Object change Event Args</summary>
-	public sealed class CrashUpdateArgs
+	public sealed class CrashUpdateArgs : EventArgs
 	{
+		/// <summary>The modified Crash Object</summary>
 		public readonly CrashObject CrashObject;
 
+		/// <summary>The Crash Doc of these Args</summary>
+		public readonly CrashDoc Doc;
+
+		/// <summary>Object Updates</summary>
 		public readonly Dictionary<string, string> Updates;
 
-		public CrashUpdateArgs(CrashObject crashObject, Dictionary<string, string> updates)
+		/// <summary>Default constructor</summary>
+		/// <param name="crashObject">The modified Crash Object</param>
+		/// <param name="updates">The given updates</param>
+		public CrashUpdateArgs(CrashDoc crashDoc, CrashObject crashObject, Dictionary<string, string> updates)
 		{
+			Doc = crashDoc;
 			CrashObject = crashObject;
 			Updates = updates;
 		}

--- a/src/Crash.Handlers/InternalEvents/CrashViewArgs.cs
+++ b/src/Crash.Handlers/InternalEvents/CrashViewArgs.cs
@@ -1,4 +1,5 @@
-﻿using Crash.Geometry;
+﻿using Crash.Common.Document;
+using Crash.Geometry;
 
 using Rhino.Display;
 
@@ -7,6 +8,9 @@ namespace Crash.Handlers.InternalEvents
 	/// <summary>Wraps Rhino View Event Args</summary>
 	public sealed class CrashViewArgs : EventArgs
 	{
+		/// <summary>The Crash Doc of these Args</summary>
+		public readonly CrashDoc Doc;
+
 		/// <summary>The Camera Location of the Event</summary>
 		public readonly CPoint Location;
 
@@ -14,16 +18,17 @@ namespace Crash.Handlers.InternalEvents
 		public readonly CPoint Target;
 
 		/// <summary>Lazy Constructor</summary>
-		internal CrashViewArgs(RhinoView view)
-			: this(view.ActiveViewport.CameraLocation.ToCrash(),
+		internal CrashViewArgs(CrashDoc crashDoc, RhinoView view)
+			: this(crashDoc, view.ActiveViewport.CameraLocation.ToCrash(),
 			       view.ActiveViewport.CameraTarget.ToCrash())
 		{
 		}
 
 
 		/// <summary>Constructor mainly for Tests</summary>
-		internal CrashViewArgs(CPoint location, CPoint target)
+		internal CrashViewArgs(CrashDoc crashDoc, CPoint location, CPoint target)
 		{
+			Doc = crashDoc;
 			Location = location;
 			Target = target;
 		}

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -302,8 +302,6 @@ namespace Crash.Handlers.InternalEvents
 				return;
 			}
 
-			CrashApp.Log($"{nameof(CaptureRhinoViewModified)} event fired.", LogLevel.Trace);
-
 			var crashDoc = CrashDocRegistry.GetRelatedDocument(args.View.Document);
 			if (crashDoc is null)
 			{

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -1,0 +1,127 @@
+﻿using Crash.Common.App;
+
+using Microsoft.Extensions.Logging;
+
+using Rhino;
+using Rhino.Display;
+using Rhino.DocObjects;
+
+namespace Crash.Handlers.InternalEvents
+{
+	internal class EventWrapper : IDisposable
+	{
+		internal EventWrapper()
+		{
+			RegisterDefaultEvents();
+		}
+
+		public void Dispose()
+		{
+			DeRegisterDefaultEvents();
+		}
+
+		private event AsyncEventHandler<CrashObjectEventArgs>? AddCrashObject;
+		private event AsyncEventHandler<CrashObjectEventArgs>? DeleteCrashObject;
+		private event AsyncEventHandler<CrashObjectEventArgs>? TransformCrashObject;
+		private event AsyncEventHandler<CrashObjectEventArgs>? SelectCrashObjects;
+		private event AsyncEventHandler<CrashObjectEventArgs>? DeSelectCrashObjects;
+		private event AsyncEventHandler<CrashObjectEventArgs>? UpdateCrashObject;
+		private event AsyncEventHandler<CrashObjectEventArgs>? CrashViewModified;
+
+		private async void CaptureAddRhinoObject(object sender, RhinoObjectEventArgs args)
+		{
+			try
+			{
+				CrashApp.Log($"{nameof(AddCrashObject)} event fired.", LogLevel.Trace);
+
+				var crashDoc =
+					CrashDocRegistry.GetRelatedDocument(args.TheObject.Document);
+				if (crashDoc is null)
+				{
+					return;
+				}
+
+				// object HAS a Crash ID
+
+				if (crashDoc.DocumentIsBusy)
+				{
+					return;
+				}
+
+				var crashArgs = new CrashObjectEventArgs(args.TheObject);
+				if (AddCrashObject is not null)
+				{
+					await AddCrashObject.Invoke(sender, crashArgs);
+				}
+			}
+			catch (Exception e)
+			{
+				CrashApp.Log(e.Message);
+				Console.WriteLine(e);
+				throw;
+			}
+		}
+
+		private async void CaptureDeleteRhinoObject(object sender, RhinoObjectEventArgs args) { }
+
+		private async void CaptureTransformRhinoObject(object sender, RhinoTransformObjectsEventArgs args) { }
+
+		private async void CaptureSelectRhinoObjects(object sender, RhinoObjectSelectionEventArgs args) { }
+
+		private async void CaptureDeselectRhinoObjects(object sender, RhinoObjectSelectionEventArgs args) { }
+
+		private async void CaptureDeselectAllRhinoObjects(object sender, RhinoDeselectAllObjectsEventArgs args) { }
+
+		private async void CaptureModifyRhinoObjectAttributes(object sender, RhinoModifyObjectAttributesEventArgs args)
+		{
+		}
+
+		private async void CaptureUserStringChanged(object sender, RhinoDoc.UserStringChangedArgs args) { }
+
+		private async void CaptureRhinoViewModified(object sender, ViewEventArgs args) { }
+
+		private void RegisterDefaultEvents()
+		{
+			// Object Events
+			RhinoDoc.AddRhinoObject += CaptureAddRhinoObject;
+			RhinoDoc.AddRhinoObject += CaptureAddRhinoObject;
+			RhinoDoc.DeleteRhinoObject += CaptureDeleteRhinoObject;
+			RhinoDoc.BeforeTransformObjects += CaptureTransformRhinoObject;
+			RhinoDoc.DeselectObjects += CaptureDeselectRhinoObjects;
+			RhinoDoc.DeselectAllObjects += CaptureDeselectAllRhinoObjects;
+			RhinoDoc.SelectObjects += CaptureSelectRhinoObjects;
+			RhinoDoc.ModifyObjectAttributes += CaptureModifyRhinoObjectAttributes;
+			RhinoDoc.UserStringChanged += CaptureUserStringChanged;
+
+			// Doc Events
+			// TODO : Implement
+			// RhinoDoc.BeginOpenDocument += RhinoDocOnBeginOpenDocument;
+
+			// View Events
+			RhinoView.Modified += CaptureRhinoViewModified;
+		}
+
+		private void DeRegisterDefaultEvents()
+		{
+			// Object Events
+			RhinoDoc.AddRhinoObject -= CaptureAddRhinoObject;
+			RhinoDoc.AddRhinoObject -= CaptureAddRhinoObject;
+			RhinoDoc.DeleteRhinoObject -= CaptureDeleteRhinoObject;
+			RhinoDoc.BeforeTransformObjects -= CaptureTransformRhinoObject;
+			RhinoDoc.DeselectObjects -= CaptureDeselectRhinoObjects;
+			RhinoDoc.DeselectAllObjects -= CaptureDeselectAllRhinoObjects;
+			RhinoDoc.SelectObjects -= CaptureSelectRhinoObjects;
+			RhinoDoc.ModifyObjectAttributes -= CaptureModifyRhinoObjectAttributes;
+			RhinoDoc.UserStringChanged -= CaptureUserStringChanged;
+
+			// Doc Events
+			// TODO : Implement
+			// RhinoDoc.BeginOpenDocument -= RhinoDocOnBeginOpenDocument;
+
+			// View Events
+			RhinoView.Modified -= CaptureRhinoViewModified;
+		}
+
+		private delegate Task AsyncEventHandler<TEventArgs>(object? sender, TEventArgs e);
+	}
+}

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -44,7 +44,7 @@ namespace Crash.Handlers.InternalEvents
 
 		private async Task CaptureAddOrUndeleteRhinoObject(object sender, RhinoObjectEventArgs args, bool undelete)
 		{
-			CrashApp.Log($"{nameof(AddCrashObject)} event fired.", LogLevel.Trace);
+			CrashApp.Log($"{nameof(CaptureAddRhinoObject)} event fired.", LogLevel.Trace);
 
 			var crashDoc =
 				CrashDocRegistry.GetRelatedDocument(args.TheObject.Document);
@@ -81,7 +81,7 @@ namespace Crash.Handlers.InternalEvents
 
 		private async void CaptureDeleteRhinoObject(object sender, RhinoObjectEventArgs args)
 		{
-			CrashApp.Log($"{nameof(AddCrashObject)} event fired.", LogLevel.Trace);
+			CrashApp.Log($"{nameof(CaptureDeleteRhinoObject)} event fired.", LogLevel.Trace);
 
 			var crashDoc =
 				CrashDocRegistry.GetRelatedDocument(args.TheObject.Document);
@@ -256,6 +256,8 @@ namespace Crash.Handlers.InternalEvents
 				return;
 			}
 
+			CrashApp.Log($"{nameof(CaptureModifyRhinoObjectAttributes)} event fired.", LogLevel.Trace);
+
 			var crashDoc = CrashDocRegistry.GetRelatedDocument(args.Document);
 			if (crashDoc is null || crashDoc.DocumentIsBusy)
 			{
@@ -295,14 +297,21 @@ namespace Crash.Handlers.InternalEvents
 
 		private async void CaptureRhinoViewModified(object sender, ViewEventArgs args)
 		{
+			if (CrashViewModified is null)
+			{
+				return;
+			}
+
+			CrashApp.Log($"{nameof(CaptureRhinoViewModified)} event fired.", LogLevel.Trace);
+
+			var crashDoc = CrashDocRegistry.GetRelatedDocument(args.View.Document);
+			if (crashDoc is null)
+			{
+				return;
+			}
+
 			try
 			{
-				if (CrashViewModified is null)
-				{
-					return;
-				}
-
-				var crashDoc = CrashDocRegistry.GetRelatedDocument(args.View.Document);
 				var viewArgs = new CrashViewArgs(crashDoc, args.View);
 				await CrashViewModified.Invoke(sender, viewArgs);
 			}

--- a/src/Crash.Handlers/Plugins/CreateRecieveArgs.cs
+++ b/src/Crash.Handlers/Plugins/CreateRecieveArgs.cs
@@ -1,7 +1,5 @@
 ﻿using Crash.Common.Document;
 
-using Rhino;
-
 namespace Crash.Handlers.Plugins
 {
 	/// <summary>A wrapper for Crash Args</summary>
@@ -22,12 +20,6 @@ namespace Crash.Handlers.Plugins
 			Action = action;
 			Args = args ?? throw new ArgumentNullException(nameof(args));
 			Doc = doc ?? throw new ArgumentNullException(nameof(doc));
-		}
-
-		/// <summary>Constructor with Rhino Doc</summary>
-		public CreateRecieveArgs(ChangeAction action, EventArgs args, RhinoDoc doc)
-			: this(action, args, CrashDocRegistry.GetRelatedDocument(doc))
-		{
 		}
 	}
 }

--- a/src/Crash.Handlers/Plugins/EventDispatcher.cs
+++ b/src/Crash.Handlers/Plugins/EventDispatcher.cs
@@ -153,7 +153,7 @@ namespace Crash.Handlers.Plugins
 			}
 		}
 
-		private void RegisterUser(CrashDoc doc, Change change)
+		private static void RegisterUser(CrashDoc doc, Change change)
 		{
 			if (!doc.Users.Add(change.Owner))
 			{

--- a/src/Crash.Handlers/Plugins/EventDispatcher.cs
+++ b/src/Crash.Handlers/Plugins/EventDispatcher.cs
@@ -204,7 +204,6 @@ namespace Crash.Handlers.Plugins
 		private async Task NotifyServerOfCrashViewModified(object sender, CrashViewArgs crashArgs)
 		{
 			await NotifyServerAsync(ChangeAction.Add, sender, crashArgs, crashArgs.Doc);
-			CrashApp.Log($"{nameof(NotifyServerOfCrashViewModified)} notified server.", LogLevel.Trace);
 		}
 
 		// TODO : Use End?

--- a/src/Crash.Handlers/Plugins/EventDispatcher.cs
+++ b/src/Crash.Handlers/Plugins/EventDispatcher.cs
@@ -2,12 +2,10 @@
 using Crash.Common.Document;
 using Crash.Common.Logging;
 using Crash.Handlers.InternalEvents;
-using Crash.Utils;
 
 using Microsoft.Extensions.Logging;
 
 using Rhino;
-using Rhino.Display;
 using Rhino.DocObjects;
 
 namespace Crash.Handlers.Plugins
@@ -20,6 +18,8 @@ namespace Crash.Handlers.Plugins
 
 		private readonly Dictionary<ChangeAction, List<IChangeCreateAction>> _createActions;
 		private readonly Dictionary<string, List<IChangeRecieveAction>> _recieveActions;
+
+		private EventWrapper _eventWrapper;
 
 		/// <summary>Default Constructor</summary>
 		public EventDispatcher()
@@ -68,8 +68,8 @@ namespace Crash.Handlers.Plugins
 		/// <param name="changeAction">The ChangeAction</param>
 		/// <param name="sender">The sender of the Event</param>
 		/// <param name="args">The EventArgs</param>
-		/// <param name="doc">The associated RhinoDoc</param>
-		public async Task NotifyServerAsync(ChangeAction changeAction, object sender, EventArgs args, RhinoDoc doc)
+		/// <param name="crashDoc">The associated RhinoDoc</param>
+		public async Task NotifyServerAsync(ChangeAction changeAction, object sender, EventArgs args, CrashDoc crashDoc)
 		{
 			if (!_createActions.TryGetValue(changeAction, out var actionChain))
 			{
@@ -81,14 +81,7 @@ namespace Crash.Handlers.Plugins
 				return;
 			}
 
-			var crashArgs = new CreateRecieveArgs(changeAction, args, doc);
-
-			var crashDoc = CrashDocRegistry.GetRelatedDocument(doc);
-			if (null == crashDoc)
-			{
-				CrashApp.Log("CrashDoc was null", LogLevel.Trace);
-				return;
-			}
+			var crashArgs = new CreateRecieveArgs(changeAction, args, crashDoc);
 
 			var changes = Enumerable.Empty<Change>();
 			foreach (var action in actionChain)
@@ -142,7 +135,7 @@ namespace Crash.Handlers.Plugins
 				return;
 			}
 
-			await RegisterUserAsync(doc, change);
+			RegisterUser(doc, change);
 
 			foreach (var recieveAction in recievers)
 			{
@@ -160,7 +153,7 @@ namespace Crash.Handlers.Plugins
 			}
 		}
 
-		private async Task RegisterUserAsync(CrashDoc doc, Change change)
+		private void RegisterUser(CrashDoc doc, Change change)
 		{
 			if (!doc.Users.Add(change.Owner))
 			{
@@ -170,244 +163,48 @@ namespace Crash.Handlers.Plugins
 			CrashApp.Log($"User {change.Owner} registered.", LogLevel.Trace);
 		}
 
-		private void AddRhinoObject(object sender, RhinoObjectEventArgs args)
+		private async Task NotifyServerOfAddCrashObject(object sender, CrashObjectEventArgs args)
 		{
-			CrashApp.Log($"{nameof(AddRhinoObject)} event fired.", LogLevel.Trace);
-
-			var crashDoc =
-				CrashDocRegistry.GetRelatedDocument(args.TheObject.Document);
-			if (crashDoc is null)
-			{
-				return;
-			}
-
-			// object HAS a Crash ID
-
-			if (crashDoc.DocumentIsBusy)
-			{
-				return;
-			}
-
-			// TODO : This needs to be used carefully
-			if (!crashDoc.RealisedChangeTable.TryGetChangeId(args.TheObject.Id, out _))
-			{
-				args.TheObject.Geometry.UserDictionary.Clear();
-			}
-
-			var crashArgs = new CrashObjectEventArgs(args.TheObject);
-			NotifyServerAsync(ChangeAction.Add | ChangeAction.Temporary, sender,
-			                  crashArgs, args.TheObject.Document);
-
-			CrashApp.Log($"{nameof(AddRhinoObject)} notified server.", LogLevel.Trace);
+			// TODO : Include Update?
+			await NotifyServerAsync(ChangeAction.Add | ChangeAction.Temporary, sender,
+			                        args, args.Doc);
+			CrashApp.Log($"{nameof(NotifyServerOfAddCrashObject)} notified server.", LogLevel.Trace);
 		}
 
-		private void DeleteRhinoObject(object sender, RhinoObjectEventArgs args)
+		private async Task NotifyServerOfDeleteCrashObject(object sender, CrashObjectEventArgs crashArgs)
 		{
-			CrashApp.Log($"{nameof(DeleteRhinoObject)} event fired.", LogLevel.Trace);
-
-			var crashDoc =
-				CrashDocRegistry.GetRelatedDocument(args.TheObject.Document);
-			if (crashDoc is null)
-			{
-				return;
-			}
-
-			if (crashDoc.DocumentIsBusy)
-			{
-				return;
-			}
-
-			// Add check for IS Transforming
-
-			args.TheObject.TryGetChangeId(out var changeId);
-			if (changeId == Guid.Empty)
-			{
-				return;
-			}
-
-			var crashArgs = new CrashObjectEventArgs(args.TheObject, changeId);
-			NotifyServerAsync(ChangeAction.Remove, sender, crashArgs,
-			                  args.TheObject.Document);
-			crashDoc.RealisedChangeTable.RemoveChange(changeId);
-
-			CrashApp.Log($"{nameof(DeleteRhinoObject)} notified server.", LogLevel.Trace);
+			await NotifyServerAsync(ChangeAction.Remove, sender, crashArgs, crashArgs.Doc);
+			CrashApp.Log($"{nameof(NotifyServerOfDeleteCrashObject)} notified server.", LogLevel.Trace);
 		}
 
-		private void TransformRhinoObject(object sender, RhinoTransformObjectsEventArgs args)
+		private async Task NotifyServerOfTransformCrashObject(object sender, CrashTransformEventArgs crashArgs)
 		{
-			if (args.GripCount > 0)
-			{
-				return;
-			}
-
-			CrashApp.Log($"{nameof(TransformRhinoObject)} event fired.", LogLevel.Trace);
-
-			var rhinoDoc = args.Objects
-			                   .FirstOrDefault(o => o.Document is not null)
-			                   .Document;
-
-			var crashDoc = CrashDocRegistry.GetRelatedDocument(rhinoDoc);
-			if (crashDoc is null)
-			{
-				return;
-			}
-
-			if (crashDoc is { CopyIsActive: false, DocumentIsBusy: true })
-			{
-				return;
-			}
-
-			var crashArgs =
-				new CrashTransformEventArgs(args.Transform.ToCrash(),
-				                            args.Objects.Select(o => new CrashObject(o)),
-				                            args.ObjectsWillBeCopied);
-
-			NotifyServerAsync(ChangeAction.Transform, sender, crashArgs, rhinoDoc);
-
-			CrashApp.Log($"{nameof(TransformRhinoObject)} notified server.", LogLevel.Trace);
+			await NotifyServerAsync(ChangeAction.Transform, sender, crashArgs, crashArgs.Doc);
+			CrashApp.Log($"{nameof(NotifyServerOfTransformCrashObject)} notified server.", LogLevel.Trace);
 		}
 
-		private void DeselectRhinoObjects(object sender, RhinoObjectSelectionEventArgs args)
+		private async Task NotifyServerOfSelectCrashObjects(object sender, CrashSelectionEventArgs crashArgs)
 		{
-			CrashApp.Log($"{nameof(DeselectRhinoObjects)} event fired.", LogLevel.Trace);
-
-			var crashDoc = CrashDocRegistry.GetRelatedDocument(args.Document);
-
-			if (crashDoc is null)
-			{
-				return;
-			}
-
-			if (crashDoc.DocumentIsBusy)
-			{
-				return;
-			}
-
-			foreach (var rhinoObject in args.RhinoObjects)
-			{
-				if (!rhinoObject.TryGetChangeId(out var changeId))
-				{
-					continue;
-				}
-
-				crashDoc.RealisedChangeTable.RemoveSelected(changeId);
-			}
-
-			var crashArgs =
-				CrashSelectionEventArgs.CreateDeSelectionEvent(args.RhinoObjects
-				                                                   .Select(o => new CrashObject(o)));
-			NotifyServerAsync(ChangeAction.Unlocked, sender, crashArgs, args.Document);
-
-			CrashApp.Log($"{nameof(DeselectRhinoObjects)} notified server.", LogLevel.Trace);
+			await NotifyServerAsync(ChangeAction.Locked, sender, crashArgs, crashArgs.Doc);
+			CrashApp.Log($"{nameof(NotifyServerOfSelectCrashObjects)} notified server.", LogLevel.Trace);
 		}
 
-		private void DeselectAllRhinoObjects(object sender, RhinoDeselectAllObjectsEventArgs args)
+		private async Task NotifyServerOfDeSelectCrashObjects(object sender, CrashSelectionEventArgs crashArgs)
 		{
-			CrashApp.Log($"{nameof(DeselectAllRhinoObjects)} event fired.", LogLevel.Trace);
-
-			var crashDoc = CrashDocRegistry.GetRelatedDocument(args.Document);
-
-			if (crashDoc is null)
-			{
-				return;
-			}
-
-			if (crashDoc.DocumentIsBusy)
-			{
-				return;
-			}
-
-			var currentlySelected = crashDoc.RealisedChangeTable.GetSelected();
-			var crashArgs = CrashSelectionEventArgs.CreateDeSelectionEvent(
-			                                                               currentlySelected
-				                                                               .Select(cs =>
-					                                                               new CrashObject(cs,
-						                                                               Guid.Empty)));
-			NotifyServerAsync(ChangeAction.Unlocked, sender, crashArgs,
-			                  args.Document);
-
-			crashDoc.RealisedChangeTable.ClearSelected();
-
-			CrashApp.Log($"{nameof(DeselectAllRhinoObjects)} notified server.", LogLevel.Trace);
+			await NotifyServerAsync(ChangeAction.Unlocked, sender, crashArgs, crashArgs.Doc);
+			CrashApp.Log($"{nameof(NotifyServerOfDeSelectCrashObjects)} notified server.", LogLevel.Trace);
 		}
 
-		private void SelectRhinoObjects(object sender, RhinoObjectSelectionEventArgs args)
+		private async Task NotifyServerOfUpdateCrashObject(object sender, CrashUpdateArgs args)
 		{
-			CrashApp.Log($"{nameof(SelectRhinoObjects)} event fired.", LogLevel.Trace);
-
-			var crashDoc = CrashDocRegistry.GetRelatedDocument(args.Document);
-
-			if (crashDoc is null)
-			{
-				return;
-			}
-
-			if (crashDoc.DocumentIsBusy)
-			{
-				return;
-			}
-
-			foreach (var rhinoObject in args.RhinoObjects)
-			{
-				if (!rhinoObject.TryGetChangeId(out var changeId))
-				{
-					continue;
-				}
-
-				crashDoc.RealisedChangeTable.AddSelected(changeId);
-			}
-
-			var crashArgs = CrashSelectionEventArgs.CreateSelectionEvent(args.RhinoObjects
-			                                                                 .Select(o => new CrashObject(o)));
-			NotifyServerAsync(ChangeAction.Locked, sender, crashArgs, args.Document);
-
-			CrashApp.Log($"{nameof(SelectRhinoObjects)} notified server.", LogLevel.Trace);
+			await NotifyServerAsync(ChangeAction.Update, sender, args, args.Doc);
+			CrashApp.Log($"{nameof(NotifyServerOfUpdateCrashObject)} notified server.", LogLevel.Trace);
 		}
 
-		private void ModifyRhinoObjectAttributes(object sender, RhinoModifyObjectAttributesEventArgs args)
+		private async Task NotifyServerOfCrashViewModified(object sender, CrashViewArgs crashArgs)
 		{
-			CrashApp.Log($"{nameof(ModifyRhinoObjectAttributes)} event fired.", LogLevel.Trace);
-
-			// TODO : Create Wrapper
-			NotifyServerAsync(ChangeAction.Update, sender, args, args.Document);
-
-			CrashApp.Log($"{nameof(ModifyRhinoObjectAttributes)} notified server.", LogLevel.Trace);
-		}
-
-		private void UserStringChanged(object sender, RhinoDoc.UserStringChangedArgs args)
-		{
-			CrashApp.Log($"{nameof(UserStringChanged)} event fired.", LogLevel.Trace);
-
-			// TODO : Create Wrapper
-			NotifyServerAsync(ChangeAction.Update, sender, args, args.Document);
-
-			CrashApp.Log($"{nameof(UserStringChanged)} notified server.", LogLevel.Trace);
-		}
-
-		private void RhinoViewModified(object sender, ViewEventArgs args)
-		{
-			var crashArgs = new CrashViewArgs(args.View);
-			NotifyServerAsync(ChangeAction.Add, sender, crashArgs, args.View.Document);
-		}
-
-		public void RegisterDefaultEvents()
-		{
-			// Object Events
-			RhinoDoc.AddRhinoObject += AddRhinoObject;
-			RhinoDoc.UndeleteRhinoObject += AddRhinoObject;
-			RhinoDoc.DeleteRhinoObject += DeleteRhinoObject;
-			RhinoDoc.BeforeTransformObjects += TransformRhinoObject;
-			RhinoDoc.DeselectObjects += DeselectRhinoObjects;
-			RhinoDoc.DeselectAllObjects += DeselectAllRhinoObjects;
-			RhinoDoc.SelectObjects += SelectRhinoObjects;
-			RhinoDoc.ModifyObjectAttributes += ModifyRhinoObjectAttributes;
-			RhinoDoc.UserStringChanged += UserStringChanged;
-
-			// Doc Events
-			RhinoDoc.BeginOpenDocument += RhinoDocOnBeginOpenDocument;
-
-			// View Events
-			RhinoView.Modified += RhinoViewModified;
+			await NotifyServerAsync(ChangeAction.Add, sender, crashArgs, crashArgs.Doc);
+			CrashApp.Log($"{nameof(NotifyServerOfCrashViewModified)} notified server.", LogLevel.Trace);
 		}
 
 		// TODO : Use End?
@@ -426,27 +223,24 @@ namespace Crash.Handlers.Plugins
 			}
 		}
 
-		public void DeRegisterDefaultEvents()
+		public void RegisterDefaultServerNotifiers()
 		{
-			// Object Events
-			RhinoDoc.AddRhinoObject -= AddRhinoObject;
-			RhinoDoc.UndeleteRhinoObject -= AddRhinoObject;
-			RhinoDoc.DeleteRhinoObject -= DeleteRhinoObject;
-			RhinoDoc.BeforeTransformObjects -= TransformRhinoObject;
-			RhinoDoc.DeselectObjects -= DeselectRhinoObjects;
-			RhinoDoc.DeselectAllObjects -= DeselectAllRhinoObjects;
-			RhinoDoc.SelectObjects -= SelectRhinoObjects;
-			RhinoDoc.ModifyObjectAttributes -= ModifyRhinoObjectAttributes;
-			RhinoDoc.UserStringChanged -= UserStringChanged;
-
-			// Doc Events
-			RhinoDoc.BeginOpenDocument -= RhinoDocOnBeginOpenDocument;
-
-			// View Events
-			RhinoView.Modified -= RhinoViewModified;
+			_eventWrapper = new EventWrapper();
+			_eventWrapper.AddCrashObject += NotifyServerOfAddCrashObject;
+			_eventWrapper.DeleteCrashObject += NotifyServerOfDeleteCrashObject;
+			_eventWrapper.TransformCrashObject += NotifyServerOfTransformCrashObject;
+			_eventWrapper.SelectCrashObjects += NotifyServerOfSelectCrashObjects;
+			_eventWrapper.DeSelectCrashObjects += NotifyServerOfDeSelectCrashObjects;
+			_eventWrapper.UpdateCrashObject += NotifyServerOfUpdateCrashObject;
+			_eventWrapper.CrashViewModified += NotifyServerOfCrashViewModified;
 		}
 
-#pragma warning disable VSTHRD101 // Avoid unsupported async delegates
+		public void DeregisterDefaultServerCalls()
+		{
+			_eventWrapper.Dispose();
+		}
+
+
 		/// <summary>
 		///     Registers all default server calls.
 		///     If you need to create custom calls do this elsewhere.
@@ -486,6 +280,5 @@ namespace Crash.Handlers.Plugins
 			                                       };
 			;
 		}
-#pragma warning restore VSTHRD101 // Avoid unsupported async delegates
 	}
 }

--- a/src/Crash.Handlers/Plugins/Geometry/Create/GeometryTransformAction.cs
+++ b/src/Crash.Handlers/Plugins/Geometry/Create/GeometryTransformAction.cs
@@ -20,6 +20,7 @@ namespace Crash.Handlers.Plugins.Geometry.Create
 
 		public bool TryConvert(object sender, CreateRecieveArgs crashArgs, out IEnumerable<Change> changes)
 		{
+			// TODO : Transform such as stretch creates new Change!
 			changes = Array.Empty<Change>();
 			if (crashArgs.Args is not CrashTransformEventArgs transformArgs)
 			{

--- a/src/Crash.Handlers/Plugins/Geometry/Create/GeometryTransformAction.cs
+++ b/src/Crash.Handlers/Plugins/Geometry/Create/GeometryTransformAction.cs
@@ -44,7 +44,7 @@ namespace Crash.Handlers.Plugins.Geometry.Create
 
 					var changeId = Guid.NewGuid();
 					var createArgs = new CreateRecieveArgs(ChangeAction.Add | ChangeAction.Temporary,
-					                                       new CrashObjectEventArgs(geometry,
+					                                       new CrashObjectEventArgs(crashArgs.Doc, geometry,
 							                                        crashObject.RhinoId, changeId),
 					                                       crashArgs.Doc);
 

--- a/src/Crash.Handlers/Utils/Geometry.cs
+++ b/src/Crash.Handlers/Utils/Geometry.cs
@@ -1,8 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using Crash.Geometry;
+﻿using Crash.Geometry;
 
 using Rhino.Geometry;
 

--- a/src/Crash.Handlers/Utils/RhinoObjectAttributesUtils.cs
+++ b/src/Crash.Handlers/Utils/RhinoObjectAttributesUtils.cs
@@ -1,0 +1,194 @@
+﻿using Rhino.DocObjects;
+
+namespace Crash.Handlers
+{
+	public static class RhinoObjectAttributesUtils
+	{
+		// TODO : Move
+		internal static Dictionary<string, string> GetAttributeDifferencesAsDictionary(ObjectAttributes oldAttributes,
+			ObjectAttributes newAttributes)
+		{
+			var results = new Dictionary<string, string>();
+			if (!oldAttributes.Space.Equals(newAttributes.Space))
+			{
+				results.Add(nameof(ObjectAttributes.Space), newAttributes.Space.ToString());
+			}
+
+			if (!oldAttributes.Visible.Equals(newAttributes.Visible))
+			{
+				results.Add(nameof(ObjectAttributes.Visible),
+				            newAttributes.Visible ? bool.TrueString : bool.FalseString);
+			}
+
+			if (!oldAttributes.Name.Equals(newAttributes.Name))
+			{
+				results.Add(nameof(ObjectAttributes.Name), newAttributes.Name);
+			}
+
+			if (!oldAttributes.Url.Equals(newAttributes.Url))
+			{
+				results.Add(nameof(ObjectAttributes.Url), newAttributes.Url);
+			}
+
+			return results;
+			/* Currently Unsupported
+			   if (!oldAttributes.CastsShadows.Equals(newAttributes.CastsShadows))
+			   {
+			   results.Add(nameof(ObjectAttributes.CastsShadows), newAttributes.CastsShadows);
+			   }
+			   if (!oldAttributes.ClipParticipationForAll.Equals(newAttributes.ClipParticipationForAll))
+			   {
+			   results.Add(nameof(ObjectAttributes.ClipParticipationForAll), newAttributes.ClipParticipationForAll);
+			   }
+			   if (!oldAttributes.ClipParticipationForNone.Equals(newAttributes.ClipParticipationForNone))
+			   {
+			   results.Add(nameof(ObjectAttributes.ClipParticipationForNone), newAttributes.ClipParticipationForNone);
+			   }
+			   if (!oldAttributes.HasMapping.Equals(newAttributes.HasMapping))
+			   {
+			   results.Add(nameof(ObjectAttributes.HasMapping), newAttributes.HasMapping);
+			   }
+			   if (!oldAttributes.HatchBoundaryVisible.Equals(newAttributes.HatchBoundaryVisible))
+			   {
+			   results.Add(nameof(ObjectAttributes.HatchBoundaryVisible), newAttributes.HatchBoundaryVisible);
+			   }
+			   if (!oldAttributes.IsInstanceDefinitionObject.Equals(newAttributes.IsInstanceDefinitionObject))
+			   {
+			   results.Add(nameof(ObjectAttributes.IsInstanceDefinitionObject), newAttributes.IsInstanceDefinitionObject);
+			   }
+			   if (!oldAttributes.ReceivesShadows.Equals(newAttributes.ReceivesShadows))
+			   {
+			   results.Add(nameof(ObjectAttributes.ReceivesShadows), newAttributes.ReceivesShadows);
+			   }
+			   if (!oldAttributes.HatchBackgroundFillColor.Equals(newAttributes.HatchBackgroundFillColor))
+			   {
+			   results.Add(nameof(ObjectAttributes.HatchBackgroundFillColor), newAttributes.HatchBackgroundFillColor);
+			   }
+			   if (!oldAttributes.ObjectColor.Equals(newAttributes.ObjectColor))
+			   {
+			   results.Add(nameof(ObjectAttributes.ObjectColor), newAttributes.ObjectColor);
+			   }
+			   if (!oldAttributes.PlotColor.Equals(newAttributes.PlotColor))
+			   {
+			   results.Add(nameof(ObjectAttributes.PlotColor), newAttributes.PlotColor);
+			   }
+			   if (!oldAttributes.Decals.Equals(newAttributes.Decals))
+			   {
+			   results.Add(nameof(ObjectAttributes.Decals), newAttributes.Decals);
+			   }
+			   if (!oldAttributes.LinetypePatternScale.Equals(newAttributes.LinetypePatternScale))
+			   {
+			   results.Add(nameof(ObjectAttributes.LinetypePatternScale), newAttributes.LinetypePatternScale);
+			   }
+			   if (!oldAttributes.PlotWeight.Equals(newAttributes.PlotWeight))
+			   {
+			   results.Add(nameof(ObjectAttributes.PlotWeight), newAttributes.PlotWeight);
+			   }
+			   if (!oldAttributes.SectionHatchRotationRadians.Equals(newAttributes.SectionHatchRotationRadians))
+			   {
+			   results.Add(nameof(ObjectAttributes.SectionHatchRotationRadians), newAttributes.SectionHatchRotationRadians);
+			   }
+			   if (!oldAttributes.SectionHatchScale.Equals(newAttributes.SectionHatchScale))
+			   {
+			   results.Add(nameof(ObjectAttributes.SectionHatchScale), newAttributes.SectionHatchScale);
+			   }
+			   if (!oldAttributes.ObjectFrameFlags.Equals(newAttributes.ObjectFrameFlags))
+			   {
+			   results.Add(nameof(ObjectAttributes.ObjectFrameFlags), newAttributes.ObjectFrameFlags);
+			   }
+			   if (!oldAttributes.File3dmMeshModifiers.Equals(newAttributes.File3dmMeshModifiers))
+			   {
+			   results.Add(nameof(ObjectAttributes.File3dmMeshModifiers), newAttributes.File3dmMeshModifiers);
+			   }
+			   if (!oldAttributes.ViewportId.Equals(newAttributes.ViewportId))
+			   {
+			   results.Add(nameof(ObjectAttributes.ViewportId), newAttributes.ViewportId);
+			   }
+			   if (!oldAttributes.DisplayOrder.Equals(newAttributes.DisplayOrder))
+			   {
+			   results.Add(nameof(ObjectAttributes.DisplayOrder), newAttributes.DisplayOrder);
+			   }
+			   if (!oldAttributes.GroupCount.Equals(newAttributes.GroupCount))
+			   {
+			   results.Add(nameof(ObjectAttributes.GroupCount), newAttributes.GroupCount);
+			   }
+			   if (!oldAttributes.LayerIndex.Equals(newAttributes.LayerIndex))
+			   {
+			   results.Add(nameof(ObjectAttributes.LayerIndex), newAttributes.LayerIndex);
+			   }
+			   if (!oldAttributes.LinetypeIndex.Equals(newAttributes.LinetypeIndex))
+			   {
+			   results.Add(nameof(ObjectAttributes.LinetypeIndex), newAttributes.LinetypeIndex);
+			   }
+			   if (!oldAttributes.MaterialIndex.Equals(newAttributes.MaterialIndex))
+			   {
+			   results.Add(nameof(ObjectAttributes.MaterialIndex), newAttributes.MaterialIndex);
+			   }
+			   if (!oldAttributes.SectionHatchIndex.Equals(newAttributes.SectionHatchIndex))
+			   {
+			   results.Add(nameof(ObjectAttributes.SectionHatchIndex), newAttributes.SectionHatchIndex);
+			   }
+			   if (!oldAttributes.WireDensity.Equals(newAttributes.WireDensity))
+			   {
+			   results.Add(nameof(ObjectAttributes.WireDensity), newAttributes.WireDensity);
+			   }
+			   if (!oldAttributes.MaterialRefs.Equals(newAttributes.MaterialRefs))
+			   {
+			   results.Add(nameof(ObjectAttributes.MaterialRefs), newAttributes.MaterialRefs);
+			   }
+			   if (!oldAttributes.CustomMeshingParameters.Equals(newAttributes.CustomMeshingParameters))
+			   {
+			   results.Add(nameof(ObjectAttributes.CustomMeshingParameters), newAttributes.CustomMeshingParameters);
+			   }
+			   if (!oldAttributes.ClipParticipationSource.Equals(newAttributes.ClipParticipationSource))
+			   {
+			   results.Add(nameof(ObjectAttributes.ClipParticipationSource), newAttributes.ClipParticipationSource);
+			   }
+			   if (!oldAttributes.ColorSource.Equals(newAttributes.ColorSource))
+			   {
+			   results.Add(nameof(ObjectAttributes.ColorSource), newAttributes.ColorSource);
+			   }
+			   if (!oldAttributes.ObjectDecoration.Equals(newAttributes.ObjectDecoration))
+			   {
+			   results.Add(nameof(ObjectAttributes.ObjectDecoration), newAttributes.ObjectDecoration);
+			   }
+			   if (!oldAttributes.LinetypeSource.Equals(newAttributes.LinetypeSource))
+			   {
+			   results.Add(nameof(ObjectAttributes.LinetypeSource), newAttributes.LinetypeSource);
+			   }
+			   if (!oldAttributes.MaterialSource.Equals(newAttributes.MaterialSource))
+			   {
+			   results.Add(nameof(ObjectAttributes.MaterialSource), newAttributes.MaterialSource);
+			   }
+			   if (!oldAttributes.Mode.Equals(newAttributes.Mode))
+			   {
+			   results.Add(nameof(ObjectAttributes.Mode), newAttributes.Mode);
+			   }
+			   if (!oldAttributes.PlotColorSource.Equals(newAttributes.PlotColorSource))
+			   {
+			   results.Add(nameof(ObjectAttributes.PlotColorSource), newAttributes.PlotColorSource);
+			   }
+			   if (!oldAttributes.PlotWeightSource.Equals(newAttributes.PlotWeightSource))
+			   {
+			   results.Add(nameof(ObjectAttributes.PlotWeightSource), newAttributes.PlotWeightSource);
+			   }
+			   if (!oldAttributes.SectionAttributesSource.Equals(newAttributes.SectionAttributesSource))
+			   {
+			   results.Add(nameof(ObjectAttributes.SectionAttributesSource), newAttributes.SectionAttributesSource);
+			   }
+			   if (!oldAttributes.SectionFillRule.Equals(newAttributes.SectionFillRule))
+			   {
+			   results.Add(nameof(ObjectAttributes.SectionFillRule), newAttributes.SectionFillRule);
+			   }
+			   if (!oldAttributes.RenderMaterial.Equals(newAttributes.RenderMaterial))
+			   {
+			   results.Add(nameof(ObjectAttributes.RenderMaterial), newAttributes.RenderMaterial);
+			   }
+			   if (!oldAttributes.OCSMappingChannelId.Equals(newAttributes.OCSMappingChannelId))
+			   {
+			   results.Add(nameof(ObjectAttributes.OCSMappingChannelId), newAttributes.OCSMappingChannelId);
+			   }
+			*/
+		}
+	}
+}

--- a/src/Crash.Handlers/Utils/RhinoObjectAttributesUtils.cs
+++ b/src/Crash.Handlers/Utils/RhinoObjectAttributesUtils.cs
@@ -30,6 +30,11 @@ namespace Crash.Handlers
 				results.Add(nameof(ObjectAttributes.Url), newAttributes.Url);
 			}
 
+			if (!oldAttributes.LayerIndex.Equals(newAttributes.LayerIndex))
+			{
+				results.Add(nameof(ObjectAttributes.LayerIndex), newAttributes.LayerIndex.ToString());
+			}
+
 			return results;
 			/* Currently Unsupported
 			   if (!oldAttributes.CastsShadows.Equals(newAttributes.CastsShadows))
@@ -51,10 +56,6 @@ namespace Crash.Handlers
 			   if (!oldAttributes.HatchBoundaryVisible.Equals(newAttributes.HatchBoundaryVisible))
 			   {
 			   results.Add(nameof(ObjectAttributes.HatchBoundaryVisible), newAttributes.HatchBoundaryVisible);
-			   }
-			   if (!oldAttributes.IsInstanceDefinitionObject.Equals(newAttributes.IsInstanceDefinitionObject))
-			   {
-			   results.Add(nameof(ObjectAttributes.IsInstanceDefinitionObject), newAttributes.IsInstanceDefinitionObject);
 			   }
 			   if (!oldAttributes.ReceivesShadows.Equals(newAttributes.ReceivesShadows))
 			   {
@@ -111,10 +112,6 @@ namespace Crash.Handlers
 			   if (!oldAttributes.GroupCount.Equals(newAttributes.GroupCount))
 			   {
 			   results.Add(nameof(ObjectAttributes.GroupCount), newAttributes.GroupCount);
-			   }
-			   if (!oldAttributes.LayerIndex.Equals(newAttributes.LayerIndex))
-			   {
-			   results.Add(nameof(ObjectAttributes.LayerIndex), newAttributes.LayerIndex);
 			   }
 			   if (!oldAttributes.LinetypeIndex.Equals(newAttributes.LinetypeIndex))
 			   {

--- a/src/Crash/CrashPlugin.cs
+++ b/src/Crash/CrashPlugin.cs
@@ -46,7 +46,7 @@ namespace Crash
 
 		private void CrashDocRegistryOnDocumentDisposed(object sender, CrashEventArgs e)
 		{
-			_dispatcher.DeRegisterDefaultEvents();
+			_dispatcher.DeregisterDefaultServerCalls();
 			_dispatcher = null;
 			InteractivePipe.Active.Enabled = false;
 			InteractivePipe.ClearChangeDefinitions();
@@ -55,7 +55,7 @@ namespace Crash
 		private void CrashDocRegistryOnDocumentRegistered(object sender, CrashEventArgs e)
 		{
 			_dispatcher = new EventDispatcher();
-			_dispatcher.RegisterDefaultEvents();
+			_dispatcher.RegisterDefaultServerNotifiers();
 			RegisterDefinitions();
 			_dispatcher.RegisterDefaultServerCalls(e.CrashDoc);
 			InteractivePipe.Active.Enabled = true;

--- a/tests/Crash.Handlers.Tests/Plugins/Camera/CameraCreateActionTests.cs
+++ b/tests/Crash.Handlers.Tests/Plugins/Camera/CameraCreateActionTests.cs
@@ -29,7 +29,7 @@ namespace Crash.Handlers.Tests.Plugins
 					var location = NRhino.Random.Geometry.NPoint3d.Any().ToCrash();
 					var target = NRhino.Random.Geometry.NPoint3d.Any().ToCrash();
 
-					yield return new CrashViewArgs(location, target);
+					yield return new CrashViewArgs(null, location, target);
 				}
 			}
 		}

--- a/tests/Crash.Handlers.Tests/Plugins/CreateRecieveArgTests.cs
+++ b/tests/Crash.Handlers.Tests/Plugins/CreateRecieveArgTests.cs
@@ -3,8 +3,6 @@ using Crash.Common.Document;
 using Crash.Common.Events;
 using Crash.Handlers.Plugins;
 
-using Rhino;
-
 namespace Crash.Handlers.Tests.Plugins
 {
 	[RhinoFixture]
@@ -21,8 +19,7 @@ namespace Crash.Handlers.Tests.Plugins
 		[Test]
 		public void Creation_BadInputs()
 		{
-			Assert.Throws<ArgumentNullException>(() => new CreateRecieveArgs((ChangeAction)(-1), null, (CrashDoc)null));
-			Assert.Throws<ArgumentNullException>(() => new CreateRecieveArgs((ChangeAction)(-1), null, (RhinoDoc)null));
+			Assert.Throws<ArgumentNullException>(() => new CreateRecieveArgs((ChangeAction)(-1), null, null));
 		}
 	}
 }

--- a/tests/Crash.Handlers.Tests/Plugins/EventDispatcherTests.cs
+++ b/tests/Crash.Handlers.Tests/Plugins/EventDispatcherTests.cs
@@ -28,22 +28,22 @@ namespace Crash.Handlers.Tests.Plugins
 				var point = new Point(Point3d.Origin);
 				var rhinoId = rhinoDoc.Objects.Add(point);
 
-				var addArgs = new CrashObjectEventArgs(point, rhinoId, Guid.NewGuid());
+				var addArgs = new CrashObjectEventArgs(null, point, rhinoId, Guid.NewGuid());
 				yield return new object[]
 				             {
 					             nameof(ICrashClient.PushChangeAsync), ChangeAction.Add | ChangeAction.Temporary,
 					             addArgs
 				             };
 
-				var deleteArgs = new CrashObjectEventArgs(null, Guid.NewGuid(), Guid.NewGuid());
+				var deleteArgs = new CrashObjectEventArgs(null, null, Guid.NewGuid(), Guid.NewGuid());
 				yield return new object[] { nameof(ICrashClient.PushChangeAsync), ChangeAction.Remove, deleteArgs };
 
 				var crashObject = new CrashObject(Guid.NewGuid(), Guid.NewGuid());
-				var selectArgs = CrashSelectionEventArgs.CreateSelectionEvent(new[] { crashObject });
+				var selectArgs = CrashSelectionEventArgs.CreateSelectionEvent(null, new[] { crashObject });
 				yield return new object[] { nameof(ICrashClient.PushChangeAsync), ChangeAction.Locked, selectArgs };
 
 
-				var deSelectArgs = CrashSelectionEventArgs.CreateDeSelectionEvent(new[] { crashObject });
+				var deSelectArgs = CrashSelectionEventArgs.CreateDeSelectionEvent(null, new[] { crashObject });
 				yield return new object[] { nameof(ICrashClient.PushChangeAsync), ChangeAction.Unlocked, deSelectArgs };
 
 				// Where do Transforms go?
@@ -98,7 +98,7 @@ namespace Crash.Handlers.Tests.Plugins
 		[TestCaseSource(nameof(DispatchEvents))]
 		public async Task TestAddDispatch(string callName, ChangeAction action, EventArgs args)
 		{
-			await eventDispatcher.NotifyServerAsync(action, this, args, rhinoDoc);
+			await eventDispatcher.NotifyServerAsync(action, this, args, crashDoc);
 			AssertCallCount(callName, 1);
 		}
 

--- a/tests/Crash.Handlers.Tests/Plugins/Geometry/GeometryCreateRemoveActionTests.cs
+++ b/tests/Crash.Handlers.Tests/Plugins/Geometry/GeometryCreateRemoveActionTests.cs
@@ -35,7 +35,7 @@ namespace Crash.Handlers.Tests.Plugins
 					                                            {
 						                                            var id = rdoc.Objects.Add(geom);
 						                                            var rhinoObject = rdoc.Objects.FindId(id);
-						                                            return new CrashObjectEventArgs(rhinoObject,
+						                                            return new CrashObjectEventArgs(null, rhinoObject,
 								                                             Guid.NewGuid());
 					                                            };
 					yield return func;
@@ -54,7 +54,7 @@ namespace Crash.Handlers.Tests.Plugins
 					                                            {
 						                                            var id = rdoc.Objects.Add(geom);
 						                                            var rhinoObject = rdoc.Objects.FindId(id);
-						                                            return new CrashObjectEventArgs(rhinoObject,
+						                                            return new CrashObjectEventArgs(null, rhinoObject,
 								                                             Guid.NewGuid());
 					                                            };
 					yield return func;

--- a/tests/Crash.Handlers.Tests/Plugins/Geometry/GeometrySelectUnselectActionTests.cs
+++ b/tests/Crash.Handlers.Tests/Plugins/Geometry/GeometrySelectUnselectActionTests.cs
@@ -26,7 +26,8 @@ namespace Crash.Handlers.Tests.Plugins
 			{
 				foreach (var crashObjeect in SharedUtils.SelectObjects)
 				{
-					yield return CrashSelectionEventArgs.CreateSelectionEvent(new List<CrashObject> { crashObjeect });
+					yield return
+						CrashSelectionEventArgs.CreateSelectionEvent(null, new List<CrashObject> { crashObjeect });
 				}
 			}
 		}
@@ -37,7 +38,8 @@ namespace Crash.Handlers.Tests.Plugins
 			{
 				foreach (var crashObjeect in SharedUtils.SelectObjects)
 				{
-					yield return CrashSelectionEventArgs.CreateDeSelectionEvent(new List<CrashObject> { crashObjeect });
+					yield return
+						CrashSelectionEventArgs.CreateDeSelectionEvent(null, new List<CrashObject> { crashObjeect });
 				}
 			}
 		}

--- a/tests/Crash.Handlers.Tests/Plugins/Geometry/GeometryTransformtActionTests.cs
+++ b/tests/Crash.Handlers.Tests/Plugins/Geometry/GeometryTransformtActionTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections;
 
 using Crash.Changes;
-using Crash.Common.Changes;
 using Crash.Common.Document;
 using Crash.Geometry;
 using Crash.Handlers.InternalEvents;
@@ -36,7 +35,7 @@ namespace Crash.Handlers.Tests.Plugins
 
 					var transform = new CTransform(doubles);
 					var objects = new List<CrashObject> { crashObject };
-					yield return new CrashTransformEventArgs(transform, objects, false);
+					yield return new CrashTransformEventArgs(null, transform, objects, false);
 				}
 			}
 		}


### PR DESCRIPTION
# Description

Many of the server notifications are asynchronous methods being run without await etc.
Not only that but currently the Rhino events are being wrapped 1 for 1.

This PR does a couple of things to improve this state of affairs
1. It wraps the Rhino Events with more coherent Crash ones. e.g. Deselect All is just a Deselect event
2. UnDelete has a flag in it as I believe UnDelete caused server sync issues
	> In short, UnDelete was sending new in-place geometry to the server without clearing the transform. This PR does not explicitly fix it (that's not its purpose) but it does add a flag into the appropriate event args so that this can be caught
3. All events that subscribe to Rhino Events are now done inside an `EventWrapper`
4. This `EventWrapper` also avoids any async void problems and converts them into nicely legible async events
5. This PR also (, as I was rummaging around in events,) adds the UpdateEventArgs for Object Attributes.
6. 

_Good Reading_
https://medium.com/@a.lyskawa/the-hitchhiker-guide-to-asynchronous-events-in-c-e9840109fb53

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Uhh....

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the docs
- [x] My changes generate no new warnings