### PR TITLE
Added Undo/Redo Transform support

### DIFF
--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -340,7 +340,7 @@ namespace Crash.Handlers.InternalEvents
 			if (TransformCrashObject is null)
 				return;
 
-			var rhinoDoc = RhinoDoc.FromRuntimeSerialNumber(args.UndoSerialNumber);
+			var rhinoDoc = RhinoDoc.ActiveDoc;
 			var crashDoc = CrashDocRegistry.GetRelatedDocument(rhinoDoc);
 			if (crashDoc != ContextDocument)
 				return;

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -447,9 +447,14 @@ namespace Crash.Handlers.InternalEvents
 			if (crashDoc != ContextDocument)
 				return;
 
-			ContextDocument.DocumentIsBusy = false;
-			ContextDocument.TransformIsActive = false;
-			ContextDocument.CopyIsActive = false;
+			if (ContextDocument.DocumentIsBusy)
+				ContextDocument.DocumentIsBusy = false;
+			
+			if (ContextDocument.TransformIsActive)
+				ContextDocument.TransformIsActive = false;
+			
+			if (ContextDocument.CopyIsActive)
+				ContextDocument.CopyIsActive = false;
 		}
 
 		private void RegisterDefaultEvents()

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -347,13 +347,8 @@ namespace Crash.Handlers.InternalEvents
 			{
 				CrashDocRegistry.ActiveDoc.TransformIsActive = false;
 
-				// If the name is not equal or we have a non existant record
-				// Then the Transform was enacted, but not sent to the server
-				if (!UndoTransformRecords.TryPeek(out TransformRecord peekResult))
-				{
-					CrashDocRegistry.ActiveDoc.TransformIsActive = true;
-					return;
-				}
+				// If the name is not equal then the Transform was enacted, but not sent to the server
+				var peekResult = UndoTransformRecords.Peek();
 
 				if (!peekResult.Name.Equals(commandName))
 				{
@@ -369,13 +364,8 @@ namespace Crash.Handlers.InternalEvents
 			{
 				CrashDocRegistry.ActiveDoc.TransformIsActive = false;
 
-				// If the name is not equal or we have a non existant record
-				// Then the Transform was enacted, but not sent to the server
-				if (!UndoTransformRecords.TryPeek(out TransformRecord peekResult))
-				{
-					CrashDocRegistry.ActiveDoc.TransformIsActive = true;
-					return;
-				}
+				// If the name is not equal then the Transform was enacted, but not sent to the server
+				var peekResult = UndoTransformRecords.Peek();
 
 				if (!peekResult.Name.Equals(commandName))
 				{

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -137,6 +137,11 @@ namespace Crash.Handlers.InternalEvents
 				return;
 			}
 
+
+			var recentCommands = Command.GetMostRecentCommands();
+			var mostRecentCommand = recentCommands.Last();
+			string commandName = mostRecentCommand.DisplayString;
+
 			crashDoc.TransformIsActive = true;
 
 			try
@@ -149,11 +154,9 @@ namespace Crash.Handlers.InternalEvents
 
 				await TransformCrashObject.Invoke(sender, crashArgs);
 
-				var recentCommands = Command.GetMostRecentCommands();
-				var mostRecentCommand = recentCommands.Last();
-				string commandName = mostRecentCommand.DisplayString;
-
 				UndoTransformRecords.Push(new(commandName, crashArgs));
+
+				TransformCommands.Add(commandName);
 			}
 			catch (Exception e)
 			{
@@ -344,20 +347,9 @@ namespace Crash.Handlers.InternalEvents
 			}
 		}
 
+		private static HashSet<string> TransformCommands = new();
 		private static bool IsTransformCommand(string commandName)
-		{
-			switch (commandName.ToUpperInvariant())
-			{
-				case "DRAG":
-				case "MOVE":
-				case "SCALE":
-				case "SCALE2D":
-				case "SCALE3D":
-					return true;
-			}
-
-			return false;
-		}
+			=> TransformCommands.Contains(commandName.ToUpperInvariant());
 
 		private async void CaptureBeginCommand(object sender, CommandEventArgs args)
 		{

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -335,8 +335,15 @@ namespace Crash.Handlers.InternalEvents
 
 			// TODO : Check for Doc is busy etc?
 
+			if (args.IsBeginUndo || args.IsBeginRedo)
+			{
+				CrashDocRegistry.ActiveDoc.TransformIsActive = true;
+			}	
+
 			if (args.IsEndUndo)
 			{
+				CrashDocRegistry.ActiveDoc.TransformIsActive = false;
+
 				var transformRecord = UndoTransformRecords.Pop();
 
 				await TransformCrashObject.Invoke(sender, transformRecord.TransformArgs);
@@ -345,6 +352,8 @@ namespace Crash.Handlers.InternalEvents
 			}
 			else if (args.IsEndRedo)
 			{
+				CrashDocRegistry.ActiveDoc.TransformIsActive = false;
+
 				var transformRecord = RedoTransformRecords.Pop();
 
 				await TransformCrashObject.Invoke(sender, transformRecord.TransformArgs);

--- a/src/Crash.Handlers/Plugins/EventDispatcher.cs
+++ b/src/Crash.Handlers/Plugins/EventDispatcher.cs
@@ -195,7 +195,7 @@ namespace Crash.Handlers.Plugins
 		/// <summary>Registers the default server notifiers</summary>
 		public void RegisterDefaultServerNotifiers()
 		{
-			_eventWrapper = new EventWrapper();
+			_eventWrapper = new EventWrapper(_crashDoc);
 			_eventWrapper.AddCrashObject += NotifyServerOfAddCrashObject;
 			_eventWrapper.DeleteCrashObject += NotifyServerOfDeleteCrashObject;
 			_eventWrapper.TransformCrashObject += NotifyServerOfTransformCrashObject;


### PR DESCRIPTION
# Description

I have configured the event wrapper such that ONLY a Transform is communicated on Undos/Redos that create a Transform. This means if you use the Crash Event Notification System, transform undo/redo is taken care of for you

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] No Tests added yet

# Checklist:

- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the docs
- [x] My changes generate no new warnings
