### PR TITLE
Huge improvements to event capturing

### DIFF
--- a/src/Crash.Common/Collections/IdleQueue.cs
+++ b/src/Crash.Common/Collections/IdleQueue.cs
@@ -36,10 +36,7 @@ namespace Crash.Events
 		/// <summary>Adds an Action to the Queue</summary>
 		public void AddAction(IdleAction action)
 		{
-			if (_idleQueue.All(iq => iq.Name?.Equals(action.Name) != true))
-			{
-				_idleQueue.Enqueue(action);
-			}
+			_idleQueue.Enqueue(action);
 		}
 
 		/// <summary>Attempts to run the next Action</summary>

--- a/src/Crash.Common/Document/CrashDoc.cs
+++ b/src/Crash.Common/Document/CrashDoc.cs
@@ -50,38 +50,6 @@ namespace Crash.Common.Document
 			}
 		}
 
-		private bool _copyIsActive { get; set; }
-
-		// TODO : What if someone DOES something when we're adding stuff?
-		/// <summary>
-		///     Marks the Document as in a "Busy State" state which means
-		///     Nothing can be sent to the server
-		/// </summary>
-		public bool CopyIsActive
-		{
-			get => _copyIsActive;
-			set
-			{
-				_copyIsActive = value;
-				CrashApp.Log($"{nameof(CopyIsActive)} was set to {value}");
-			}
-		}
-
-		private bool _transformIsActive { get; set; }
-
-		/// <summary>
-		///     Marks the Document as in a "Transformation Active State" state which means
-		/// </summary>
-		public bool TransformIsActive
-		{
-			get => _transformIsActive;
-			set
-			{
-				_transformIsActive = value;
-				CrashApp.Log($"{nameof(TransformIsActive)} was set to {value}");
-			}
-		}
-
 		#region Queue
 
 		/// <summary>The Idle Queue for the Crash Document</summary>

--- a/src/Crash.Handlers/InternalEvents/CrashObject.cs
+++ b/src/Crash.Handlers/InternalEvents/CrashObject.cs
@@ -5,7 +5,7 @@ using Rhino.DocObjects;
 namespace Crash.Handlers.InternalEvents
 {
 	/// <summary>Wraps a Rhino Object and Change</summary>
-	public struct CrashObject
+	public readonly struct CrashObject
 	{
 		/// <summary>The Change Id</summary>
 		public readonly Guid ChangeId;
@@ -24,5 +24,8 @@ namespace Crash.Handlers.InternalEvents
 			ChangeId = changeId;
 			RhinoId = rhinoId;
 		}
+
+		public override int GetHashCode() => HashCode.Combine(ChangeId, RhinoId);
+
 	}
 }

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -340,7 +340,7 @@ namespace Crash.Handlers.InternalEvents
 			if (TransformCrashObject is null)
 				return;
 
-			var rhinoDoc = RhinoDoc.FromRuntimeSerialNumber(args.UndoSerialNumber);
+			var rhinoDoc = RhinoDoc.ActiveDoc;
 			var crashDoc = CrashDocRegistry.GetRelatedDocument(rhinoDoc);
 			if (crashDoc != ContextDocument)
 				return;

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -39,13 +39,10 @@ namespace Crash.Handlers.InternalEvents
 		// TODO : Include Plane Cache or otherwise
 		private record TransformRecord : IUndoRedoCache
 		{
-			public readonly string Name;
-
 			public readonly CrashTransformEventArgs TransformArgs;
 
-			internal TransformRecord(string name, CrashTransformEventArgs args)
+			internal TransformRecord(CrashTransformEventArgs args)
 			{
-				Name = name;
 				TransformArgs = args;
 			}
 
@@ -56,7 +53,7 @@ namespace Crash.Handlers.InternalEvents
 															inverseTransform,
 															TransformArgs.Objects,
 															TransformArgs.ObjectsWillBeCopied);
-				return new TransformRecord(Name, newArgs);
+				return new TransformRecord(newArgs);
 			}
 		}
 
@@ -188,28 +185,10 @@ namespace Crash.Handlers.InternalEvents
 		#region Capturers
 
 		private void CaptureAddRhinoObject(object? sender, RhinoObjectEventArgs args)
-		{
-			try
-			{
-				await CaptureAddOrUndeleteRhinoObject(sender, args, false);
-			}
-			catch (Exception e)
-			{
-				CrashApp.Log(e.Message);
-			}
-		}
+			=> CaptureAddOrUndeleteRhinoObject(sender, args, false);
 
 		private void CaptureUnDeleteRhinoObject(object? sender, RhinoObjectEventArgs args)
-		{
-			try
-			{
-				await CaptureAddOrUndeleteRhinoObject(sender, args, true);
-			}
-			catch (Exception e)
-			{
-				CrashApp.Log(e.Message);
-			}
-		}
+			=> CaptureAddOrUndeleteRhinoObject(sender, args, true);
 
 		private void CaptureAddOrUndeleteRhinoObject(object? sender, RhinoObjectEventArgs args, bool undelete)
 		{
@@ -285,20 +264,13 @@ namespace Crash.Handlers.InternalEvents
 
 				TransformIsActive = true;
 
-				string commandName = string.Empty;
-				var stack = Command.GetCommandStack();
-				if (stack is not null && stack.Any())
-				{
-					commandName = Command.LookupCommandName(stack.Last(), true);
-					TransformCommands.Add(commandName.ToUpperInvariant());
-				}
 				var transform = args.Transform.ToCrash();
 				var transformArgs =
 					new CrashTransformEventArgs(crashDoc, transform,
 												args.Objects.Select(o => new CrashObject(o)),
 												args.ObjectsWillBeCopied);
 
-				var transformRecord = new TransformRecord(commandName, transformArgs);
+				var transformRecord = new TransformRecord(transformArgs);
 				Push(transformRecord);
 			}
 			catch (Exception e)

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -133,25 +133,25 @@ namespace Crash.Handlers.InternalEvents
 			bool ignoreIfUndoActive = true,
 			bool ignoreIfRedoActive = true)
 		{
-			if (comparisonDoc != ContextDocument)
-				return true;
-
 			if (comparisonDoc is null)
 				return true;
 
-			if (!ignoreIfCopy && CopyIsActive)
+			if (comparisonDoc != ContextDocument)
 				return true;
 
-			if (!ignoreIfBusy && comparisonDoc.DocumentIsBusy)
+			if (ignoreIfCopy && CopyIsActive)
 				return true;
 
-			if (!ignoreIfTransform && TransformIsActive)
+			if (ignoreIfBusy && comparisonDoc.DocumentIsBusy)
 				return true;
 
-			if (!ignoreIfUndoActive && UndoIsActive)
+			if (ignoreIfTransform && TransformIsActive)
 				return true;
 
-			if (!ignoreIfRedoActive && RedoIsActive)
+			if (ignoreIfUndoActive && UndoIsActive)
+				return true;
+
+			if (ignoreIfRedoActive && RedoIsActive)
 				return true;
 
 			return false;
@@ -216,7 +216,7 @@ namespace Crash.Handlers.InternalEvents
 				var crashDoc =
 					CrashDocRegistry.GetRelatedDocument(args.TheObject.Document);
 
-				if (IgnoreEvent(crashDoc, false, true, true))
+				if (IgnoreEvent(crashDoc))
 				{
 					return;
 				}
@@ -251,7 +251,7 @@ namespace Crash.Handlers.InternalEvents
 								   ?.FirstOrDefault(o => o.Document is not null)
 								   ?.Document;
 				var crashDoc = CrashDocRegistry.GetRelatedDocument(rhinoDoc);
-				if (!IgnoreEvent(crashDoc, ignoreIfCopy:false))
+				if (IgnoreEvent(crashDoc, ignoreIfCopy:false))
 				{
 					return;
 				}
@@ -322,10 +322,6 @@ namespace Crash.Handlers.InternalEvents
 				CrashApp.Log($"{nameof(CaptureDeselectRhinoObjects)} event fired.", LogLevel.Trace);
 
 				var crashDoc = CrashDocRegistry.GetRelatedDocument(args.Document);
-				if (!IgnoreEvent(crashDoc))
-				{
-					return;
-				}
 
 				foreach (var rhinoObject in args.RhinoObjects)
 				{
@@ -356,10 +352,6 @@ namespace Crash.Handlers.InternalEvents
 				CrashApp.Log($"{nameof(CaptureDeselectAllRhinoObjects)} event fired.", LogLevel.Trace);
 
 				var crashDoc = CrashDocRegistry.GetRelatedDocument(args.Document);
-				if (!IgnoreEvent(crashDoc))
-				{
-					return;
-				}
 
 				var currentlySelected = crashDoc.RealisedChangeTable.GetSelected();
 				var crashObjects = currentlySelected.Select(cs => new CrashObject(cs, Guid.Empty));
@@ -395,7 +387,7 @@ namespace Crash.Handlers.InternalEvents
 			CrashApp.Log($"{nameof(CaptureModifyRhinoObjectAttributes)} event fired.", LogLevel.Trace);
 
 			var crashDoc = CrashDocRegistry.GetRelatedDocument(args.Document);
-			if (!IgnoreEvent(crashDoc))
+			if (IgnoreEvent(crashDoc))
 			{
 				return;
 			}
@@ -533,7 +525,7 @@ namespace Crash.Handlers.InternalEvents
 					await cacheAction;
 				}
 
-				foreach(var queueItem in SelectionQueue)
+				foreach(var queueItem in SelectionQueue.ToArray())
 				{
 					bool isSelected = queueItem.Value;
 					var theObject = queueItem.Key;

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -634,10 +634,6 @@ namespace Crash.Handlers.InternalEvents
 
 		#endregion
 
-		private static HashSet<string> TransformCommands = new();
-		private static bool IsTransformCommand(string commandName)
-			=> TransformCommands.Contains(commandName.ToUpperInvariant());
-
 		#region Register Events
 
 		private void RegisterDefaultEvents()

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -49,9 +49,11 @@ namespace Crash.Handlers.InternalEvents
 
 			public IUndoRedoCache GetInverse()
 			{
-				var inverseTransform = CTransform.Unset;
+				var transformCache = TransformArgs.Transform.ToRhino();
+				transformCache.TryGetInverse(out var inverseTransform);
+
 				var newArgs = new CrashTransformEventArgs(TransformArgs.Doc,
-															inverseTransform,
+															inverseTransform.ToCrash(),
 															TransformArgs.Objects,
 															TransformArgs.ObjectsWillBeCopied);
 				return new TransformRecord(newArgs);
@@ -280,7 +282,6 @@ namespace Crash.Handlers.InternalEvents
 			}
 		}
 
-		// TODO : Not using Queue for Select will result in them being sent first!
 		private void CaptureSelectRhinoObjects(object? sender, RhinoObjectSelectionEventArgs args)
 		{
 			if (SelectCrashObjects is null)
@@ -461,7 +462,8 @@ namespace Crash.Handlers.InternalEvents
 		}
 
 #pragma warning disable VSTHRD100 // Cannot avoid async void methods here
-		// TODO : Use Queue?
+		// TODO : Use Queue to prevent > 60fps being sent
+		// TODO : Use Stream?
 		private async void CaptureRhinoViewModified(object? sender, ViewEventArgs args)
 		{
 			if (CrashViewModified is null)

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -542,6 +542,8 @@ namespace Crash.Handlers.InternalEvents
 					else
 						await SendDeselectionAsync(theObject);
 				}
+
+				SelectionQueue.Clear();
 			}
 			catch (Exception e)
 			{

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -447,9 +447,14 @@ namespace Crash.Handlers.InternalEvents
 			if (crashDoc != ContextDocument)
 				return;
 
-			ContextDocument.DocumentIsBusy = false;
-			ContextDocument.TransformIsActive = false;
-			ContextDocument.CopyIsActive = false;
+			if (ContextDocument.DocumentIsBusy)
+				ContextDocument.DocumentIsBusy = false;
+			
+			if (ContextDocument.TransformIsActive)
+				ContextDocument.TransformIsActive = false;
+			
+			if (ContextDocument.CopyIsActive)
+				ContextDocument.CopyIsActive = false;
 		}
 
 		private void RegisterDefaultEvents()

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -282,6 +282,7 @@ namespace Crash.Handlers.InternalEvents
 				var crashArgs = CrashSelectionEventArgs.CreateDeSelectionEvent(crashDoc, crashObjects);
 
 				await DeSelectCrashObjects.Invoke(sender, crashArgs);
+				crashDoc.RealisedChangeTable.ClearSelected();
 			}
 			catch (Exception e)
 			{

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -347,13 +347,8 @@ namespace Crash.Handlers.InternalEvents
 			{
 				CrashDocRegistry.ActiveDoc.TransformIsActive = false;
 
-				// If the name is not equal or we have a non existant record
-				// Then the Transform was enacted, but not sent to the server
-				if (!UndoTransformRecords.TryPeek(out TransformRecord peekResult))
-				{
-					CrashDocRegistry.ActiveDoc.TransformIsActive = true;
-					return;
-				}
+				// If the name is not equal then the Transform was enacted, but not sent to the server
+				var peekResult = UndoTransformRecords.Peek();
 
 				if (!peekResult.Name.Equals(commandName))
 				{
@@ -369,13 +364,8 @@ namespace Crash.Handlers.InternalEvents
 			{
 				CrashDocRegistry.ActiveDoc.TransformIsActive = false;
 
-				// If the name is not equal or we have a non existant record
-				// Then the Transform was enacted, but not sent to the server
-				if (!UndoTransformRecords.TryPeek(out TransformRecord peekResult))
-				{
-					CrashDocRegistry.ActiveDoc.TransformIsActive = true;
-					return;
-				}
+				// If the name is not equal then the Transform was enacted, but not sent to the server
+				var peekResult = UndoTransformRecords.Peek();
 
 				if (!peekResult.Name.Equals(commandName))
 				{

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -137,6 +137,11 @@ namespace Crash.Handlers.InternalEvents
 				return;
 			}
 
+
+			var recentCommands = Command.GetMostRecentCommands();
+			var mostRecentCommand = recentCommands.Last();
+			string commandName = mostRecentCommand.DisplayString;
+
 			crashDoc.TransformIsActive = true;
 
 			try
@@ -149,11 +154,9 @@ namespace Crash.Handlers.InternalEvents
 
 				await TransformCrashObject.Invoke(sender, crashArgs);
 
-				var recentCommands = Command.GetMostRecentCommands();
-				var mostRecentCommand = recentCommands.Last();
-				string commandName = mostRecentCommand.DisplayString;
-
 				UndoTransformRecords.Push(new(commandName, crashArgs));
+
+				TransformCommands.Add(commandName);
 			}
 			catch (Exception e)
 			{
@@ -344,20 +347,9 @@ namespace Crash.Handlers.InternalEvents
 			}
 		}
 
+		private static HashSet<string> TransformCommands = new();
 		private static bool IsTransformCommand(string commandName)
-		{
-			switch (commandName.ToUpperInvariant())
-			{
-				case "DRAG":
-				case "MOVE":
-				case "SCALE":
-				case "SCALE2D":
-				case "SCALE3D":
-					return true;
-			}
-
-			return false;
-		}
+			=> TransformCommands.Contains(commandName.ToUpperInvariant());
 
 		private async void CaptureBeginCommand(object sender, CommandEventArgs args)
 		{

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -335,8 +335,15 @@ namespace Crash.Handlers.InternalEvents
 
 			// TODO : Check for Doc is busy etc?
 
+			if (args.IsBeginUndo || args.IsBeginRedo)
+			{
+				CrashDocRegistry.ActiveDoc.TransformIsActive = true;
+			}	
+
 			if (args.IsEndUndo)
 			{
+				CrashDocRegistry.ActiveDoc.TransformIsActive = false;
+
 				var transformRecord = UndoTransformRecords.Pop();
 
 				await TransformCrashObject.Invoke(sender, transformRecord.TransformArgs);
@@ -345,6 +352,8 @@ namespace Crash.Handlers.InternalEvents
 			}
 			else if (args.IsEndRedo)
 			{
+				CrashDocRegistry.ActiveDoc.TransformIsActive = false;
+
 				var transformRecord = RedoTransformRecords.Pop();
 
 				await TransformCrashObject.Invoke(sender, transformRecord.TransformArgs);

--- a/src/Crash.Handlers/InternalEvents/EventWrapper.cs
+++ b/src/Crash.Handlers/InternalEvents/EventWrapper.cs
@@ -187,8 +187,6 @@ namespace Crash.Handlers.InternalEvents
 
 		#region Capturers
 
-#pragma warning disable VSTHRD100 // Cannot avoid async void methods here
-
 		private void CaptureAddRhinoObject(object? sender, RhinoObjectEventArgs args)
 		{
 			try
@@ -494,6 +492,7 @@ namespace Crash.Handlers.InternalEvents
 			}
 		}
 
+#pragma warning disable VSTHRD100 // Cannot avoid async void methods here
 		// TODO : Use Queue?
 		private async void CaptureRhinoViewModified(object? sender, ViewEventArgs args)
 		{
@@ -518,6 +517,7 @@ namespace Crash.Handlers.InternalEvents
 				CrashApp.Log(e.Message);
 			}
 		}
+#pragma warning restore VSTHRD100 // Avoid async void methods
 
 		private void Push(IUndoRedoCache add, bool forward = true)
 		{
@@ -529,6 +529,7 @@ namespace Crash.Handlers.InternalEvents
 				RedoRecords.Push(add.GetInverse());
 		}
 
+#pragma warning disable VSTHRD100 // Cannot avoid async void methods here
 		private async void CaptureIdle(object? _, EventArgs __)
 		{
 			var crashDoc = CrashDocRegistry.GetRelatedDocument(RhinoDoc.ActiveDoc);

--- a/src/Crash.Handlers/Plugins/EventDispatcher.cs
+++ b/src/Crash.Handlers/Plugins/EventDispatcher.cs
@@ -195,7 +195,7 @@ namespace Crash.Handlers.Plugins
 		/// <summary>Registers the default server notifiers</summary>
 		public void RegisterDefaultServerNotifiers()
 		{
-			_eventWrapper = new EventWrapper();
+			_eventWrapper = new EventWrapper(_crashDoc);
 			_eventWrapper.AddCrashObject += NotifyServerOfAddCrashObject;
 			_eventWrapper.DeleteCrashObject += NotifyServerOfDeleteCrashObject;
 			_eventWrapper.TransformCrashObject += NotifyServerOfTransformCrashObject;

--- a/src/Crash.Handlers/Plugins/EventDispatcher.cs
+++ b/src/Crash.Handlers/Plugins/EventDispatcher.cs
@@ -149,7 +149,7 @@ namespace Crash.Handlers.Plugins
 			CrashApp.Log($"User {change.Owner} registered.", LogLevel.Trace);
 		}
 
-		private async Task NotifyServerOfAddCrashObject(object sender, CrashObjectEventArgs args)
+		private async Task NotifyServerOfAddCrashObject(object? sender, CrashObjectEventArgs args)
 		{
 			// TODO : Include Update?
 			await NotifyServerAsync(ChangeAction.Add | ChangeAction.Temporary, sender,
@@ -157,37 +157,37 @@ namespace Crash.Handlers.Plugins
 			CrashApp.Log($"{nameof(NotifyServerOfAddCrashObject)} notified server.", LogLevel.Trace);
 		}
 
-		private async Task NotifyServerOfDeleteCrashObject(object sender, CrashObjectEventArgs crashArgs)
+		private async Task NotifyServerOfDeleteCrashObject(object? sender, CrashObjectEventArgs crashArgs)
 		{
 			await NotifyServerAsync(ChangeAction.Remove, sender, crashArgs, crashArgs.Doc);
 			CrashApp.Log($"{nameof(NotifyServerOfDeleteCrashObject)} notified server.", LogLevel.Trace);
 		}
 
-		private async Task NotifyServerOfTransformCrashObject(object sender, CrashTransformEventArgs crashArgs)
+		private async Task NotifyServerOfTransformCrashObject(object? sender, CrashTransformEventArgs crashArgs)
 		{
 			await NotifyServerAsync(ChangeAction.Transform, sender, crashArgs, crashArgs.Doc);
 			CrashApp.Log($"{nameof(NotifyServerOfTransformCrashObject)} notified server.", LogLevel.Trace);
 		}
 
-		private async Task NotifyServerOfSelectCrashObjects(object sender, CrashSelectionEventArgs crashArgs)
+		private async Task NotifyServerOfSelectCrashObjects(object? sender, CrashSelectionEventArgs crashArgs)
 		{
 			await NotifyServerAsync(ChangeAction.Locked, sender, crashArgs, crashArgs.Doc);
 			CrashApp.Log($"{nameof(NotifyServerOfSelectCrashObjects)} notified server.", LogLevel.Trace);
 		}
 
-		private async Task NotifyServerOfDeSelectCrashObjects(object sender, CrashSelectionEventArgs crashArgs)
+		private async Task NotifyServerOfDeSelectCrashObjects(object? sender, CrashSelectionEventArgs crashArgs)
 		{
 			await NotifyServerAsync(ChangeAction.Unlocked, sender, crashArgs, crashArgs.Doc);
 			CrashApp.Log($"{nameof(NotifyServerOfDeSelectCrashObjects)} notified server.", LogLevel.Trace);
 		}
 
-		private async Task NotifyServerOfUpdateCrashObject(object sender, CrashUpdateArgs args)
+		private async Task NotifyServerOfUpdateCrashObject(object? sender, CrashUpdateArgs args)
 		{
 			await NotifyServerAsync(ChangeAction.Update, sender, args, args.Doc);
 			CrashApp.Log($"{nameof(NotifyServerOfUpdateCrashObject)} notified server.", LogLevel.Trace);
 		}
 
-		private async Task NotifyServerOfCrashViewModified(object sender, CrashViewArgs crashArgs)
+		private async Task NotifyServerOfCrashViewModified(object? sender, CrashViewArgs crashArgs)
 		{
 			await NotifyServerAsync(ChangeAction.Add, sender, crashArgs, crashArgs.Doc);
 		}

--- a/src/Crash.Handlers/Plugins/Geometry/Recieve/GeometryAddRecieveAction.cs
+++ b/src/Crash.Handlers/Plugins/Geometry/Recieve/GeometryAddRecieveAction.cs
@@ -6,6 +6,8 @@ using Crash.Events;
 using Crash.Handlers.Changes;
 using Crash.Utils;
 
+using Rhino;
+
 namespace Crash.Handlers.Plugins.Geometry.Recieve
 {
 	/// <summary>Handles recieving of Geometry</summary>
@@ -79,6 +81,10 @@ namespace Crash.Handlers.Plugins.Geometry.Recieve
 				{
 					rhinoDoc.Objects.Select(rhinoId, true, true);
 				}
+			}
+			catch(Exception ex)
+			{
+				RhinoApp.WriteLine(ex.Message);
 			}
 			finally
 			{

--- a/src/Crash/CrashRhinoPlugIn.cs
+++ b/src/Crash/CrashRhinoPlugIn.cs
@@ -7,6 +7,7 @@ using Crash.Handlers.Plugins.Geometry;
 using Crash.Handlers.Plugins.Initializers;
 
 using Rhino.PlugIns;
+using Rhino.UI.Controls;
 
 namespace Crash
 {
@@ -97,7 +98,7 @@ namespace Crash
 			}
 		}
 
-		private void LocalClientOnOnInit(object sender, CrashClient.CrashInitArgs e)
+		private async void LocalClientOnOnInit(object? sender, CrashClient.CrashInitArgs e)
 		{
 			e.CrashDoc.LocalClient.OnInit -= LocalClientOnOnInit;
 			var dispatcher = e.CrashDoc.Dispatcher as EventDispatcher;
@@ -112,8 +113,13 @@ namespace Crash
 				foreach (var change in e.Changes)
 				{
 					// TODO : Implement Async
-					dispatcher.NotifyClientAsync(e.CrashDoc, change);
+					await dispatcher.NotifyClientAsync(e.CrashDoc, change);
 				}
+			}
+			catch(Exception ex)
+			{
+				;
+				RhinoApp.WriteLine(ex.Message);
 			}
 			finally
 			{


### PR DESCRIPTION
# Description

Events in Rhino are tricky.
The goal here is to wrap them so Crash only communicates events in a cohesive fashion.
i.e if geometry is transformed, Crash only sends a Transform.
Normally in Rhino a Transform has the following Events (Which is messy)
1. Transform Deselect
2. Delete
3. Add
4. Replace
5. Select

I've used the following logic

1. The Rhino Events are false prophets
6. Do not trust any one Rhino Event, you must only act when they have all spoken, the truth can be interpreted this way
7. Cache the result of an event stack in the Undo Queue
8. On Undo, push into Redo an inverse event
9. On Undo or Redo -> Block EVERY Rhino event for they are false phrophets
2. On Undo /Redo traverse through the Undo/Redo Stack and retrieve an inverse event

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the docs
- [ ] My changes generate no new warnings
