### PR TITLE
Abstracted Tables into ICacheTable to allow for any kind of table

### DIFF
--- a/src/Crash.Common/Document/CrashDoc.cs
+++ b/src/Crash.Common/Document/CrashDoc.cs
@@ -22,8 +22,9 @@ namespace Crash.Common.Document
 			_id = Guid.NewGuid();
 
 			Users = new UserTable(this);
-			TemporaryChangeTable = new TemporaryChangeTable(this);
-			RealisedChangeTable = new RealisedChangeTable(this);
+			Tables = new CacheTable(this);
+			Tables.AddTable(new TemporaryChangeTable(this));
+			Tables.AddTable(new RealisedChangeTable(this));
 			Cameras = new CameraTable(this);
 
 			LocalClient = new CrashClient(this);
@@ -75,15 +76,20 @@ namespace Crash.Common.Document
 		#region Tables
 
 		/// <summary>The Users Table for the Crash Doc</summary>
-		public readonly UserTable Users;
+		public UserTable Users { get; }
 
 		/// <summary>The Changes Table for the Crash Doc</summary>
-		public readonly TemporaryChangeTable TemporaryChangeTable;
+		[Obsolete("Use Tables.Get<TemporaryChangeTable>()")]
+		public TemporaryChangeTable TemporaryChangeTable => Tables.Get<TemporaryChangeTable>();
 
-		public readonly RealisedChangeTable RealisedChangeTable;
+		[Obsolete("Use Tables.Get<RealisedChangeTable>()")]
+		public RealisedChangeTable RealisedChangeTable => Tables.Get<RealisedChangeTable>();
+
+		/// <summary>Stores all of the Tables in the Crash Doc</summary>
+		public CacheTable Tables { get; }
 
 		/// <summary>The Camera Table for the crash Doc</summary>
-		public readonly CameraTable Cameras;
+		public CameraTable Cameras { get; }
 
 		#endregion
 

--- a/src/Crash.Common/Tables/CacheTable.cs
+++ b/src/Crash.Common/Tables/CacheTable.cs
@@ -1,33 +1,62 @@
-using Crash.Common.Document;
+﻿using Crash.Common.Document;
 
 namespace Crash.Common.Tables
 {
+
+	/// <summary>
+	/// Stores all of the tables related to the Crash Doc
+	/// </summary>
 	public sealed class CacheTable
 	{
-		private readonly CrashDoc _crashDoc;
+		private CrashDoc CrashDoc { get; }
 
 		internal CacheTable(CrashDoc hostDoc)
 		{
-			_crashDoc = hostDoc;
+			CrashDoc = hostDoc;
 			CachedTables = new Dictionary<string, ICacheTable>();
 		}
 
 		private Dictionary<string, ICacheTable> CachedTables { get; }
 
+		/// <summary>
+		/// Adds a table into the cache
+		/// </summary>
+		/// <param name="table">The table to add</param>
 		public void AddTable(ICacheTable table)
 		{
-			var key = table.GetType().Name;
+			if (table is null) return;
+
+			var key = table.GetType().Name.ToLowerInvariant();
 			if (!CachedTables.ContainsKey(key))
 			{
 				CachedTables.Add(key, table);
 			}
 		}
 
+		/// <summary>
+		/// Returns the table, or null if it doesn't exist
+		/// </summary>
+		/// <typeparam name="TTable">The type related to the table</typeparam>
+		/// <returns>Returns the table if found, null otherwise</returns>
 		public TTable? Get<TTable>() where TTable : class
 		{
-			var key = typeof(TTable).Name;
+			var key = typeof(TTable).Name.ToLowerInvariant();
 			CachedTables.TryGetValue(key, out var table);
 			return table as TTable;
 		}
+
+		/// <summary>
+		/// Attempts to return a table
+		/// </summary>
+		/// <typeparam name="TTable">The type related to the table</typeparam>
+		/// <returns>True if the table exists</returns>
+		public bool TryGet<TTable>(out TTable table) where TTable : class
+		{
+			var key = typeof(TTable).Name.ToLowerInvariant();
+			CachedTables.TryGetValue(key, out var cachedTable);
+			table = cachedTable as TTable;
+			return table is not null;
+		}
+
 	}
 }

--- a/src/Crash.Common/Tables/CacheTable.cs
+++ b/src/Crash.Common/Tables/CacheTable.cs
@@ -1,0 +1,33 @@
+using Crash.Common.Document;
+
+namespace Crash.Common.Tables
+{
+	public sealed class CacheTable
+	{
+		private readonly CrashDoc _crashDoc;
+
+		internal CacheTable(CrashDoc hostDoc)
+		{
+			_crashDoc = hostDoc;
+			CachedTables = new Dictionary<string, ICacheTable>();
+		}
+
+		private Dictionary<string, ICacheTable> CachedTables { get; }
+
+		public void AddTable(ICacheTable table)
+		{
+			var key = table.GetType().Name;
+			if (!CachedTables.ContainsKey(key))
+			{
+				CachedTables.Add(key, table);
+			}
+		}
+
+		public TTable? Get<TTable>() where TTable : class
+		{
+			var key = typeof(TTable).Name;
+			CachedTables.TryGetValue(key, out var table);
+			return table as TTable;
+		}
+	}
+}

--- a/src/Crash.Common/Tables/ICacheTable.cs
+++ b/src/Crash.Common/Tables/ICacheTable.cs
@@ -1,0 +1,6 @@
+namespace Crash.Common.Tables
+{
+	public interface ICacheTable
+	{
+	}
+}

--- a/src/Crash.Common/Tables/RealisedChangeTable.cs
+++ b/src/Crash.Common/Tables/RealisedChangeTable.cs
@@ -16,7 +16,7 @@ namespace Crash.Common.Tables
 	///     When a realised ...
 	///     TODO : How do we solve this for Layers etc?
 	/// </summary>
-	public sealed class RealisedChangeTable
+	public sealed class RealisedChangeTable : ICacheTable
 	{
 		/// <summary>The current Crash Document</summary>
 		private readonly CrashDoc _crashDoc;

--- a/src/Crash.Common/Tables/TemporaryChangeTable.cs
+++ b/src/Crash.Common/Tables/TemporaryChangeTable.cs
@@ -11,7 +11,7 @@ namespace Crash.Common.Tables
 	///     These temporary changes are, if necessary displayed
 	///     in the pipeline to show pending changes
 	/// </summary>
-	public sealed class TemporaryChangeTable : IEnumerable<IChange>
+	public sealed class TemporaryChangeTable : IEnumerable<IChange>, ICacheTable
 	{
 		private readonly ConcurrentDictionary<Guid, IChange> _cache;
 		private readonly CrashDoc _crashDoc;
@@ -102,7 +102,7 @@ namespace Crash.Common.Tables
 		}
 
 		/// <summary>
-		/// Checks that a pairing with this RhinoId exists.
+		///     Checks that a pairing with this RhinoId exists.
 		/// </summary>
 		public bool HasPairing(Guid rhinoId)
 		{
@@ -110,7 +110,7 @@ namespace Crash.Common.Tables
 		}
 
 		/// <summary>
-		/// Attempts to find the Change associated to this RhinoId 
+		///     Attempts to find the Change associated to this RhinoId
 		/// </summary>
 		public bool TryGetChange(Guid rhinoId, out IChange change)
 		{


### PR DESCRIPTION
# Description

I've moved away from distinct tables and instead moved to a dynamic system that lets anyone, me or a plugin-creator attach a table to the Crash Document. The layers PR shows a very elegant way of when to initialise them too.
https://github.com/crashcloud/Crash/blob/02e8be1b2b9032c37bc287b45d23092427310a25/src/Crash.Handlers/Plugins/Layers/LayerChangeDefinition.cs#L12-L44

It's possible the Realised and Temporary Tables will be rewritten at some point. But it's best to keep that out of this PR.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [ ] Tested that Geometry still sends as expected.

# Checklist:

- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the docs
- [ ] My changes generate no new warnings