### PR TITLE
Removed statics from much of Crash

### DIFF
--- a/src/Crash.Common/App/CrashApp.cs
+++ b/src/Crash.Common/App/CrashApp.cs
@@ -1,12 +1,16 @@
+using Crash.Common.Document;
+
 using Microsoft.Extensions.Logging;
 
 namespace Crash.Common.App
 {
+
 	/// <summary>
 	///     A global Application class to handle Application specific logic
 	/// </summary>
 	public static class CrashApp
 	{
+
 		/// <summary>The current Log Level, anything lower won't be logged</summary>
 		private static LogLevel Level { get; } = LogLevel.Information;
 

--- a/src/Crash.Common/App/CrashInstances.cs
+++ b/src/Crash.Common/App/CrashInstances.cs
@@ -1,0 +1,86 @@
+using Crash.Common.Document;
+
+namespace Crash.Common.App
+{
+
+	public interface ICrashInstance { }
+
+	/// <summary>
+	/// Stashes Instances against a Crash Doc
+	/// This avoids statics
+	/// </summary>
+	public static class CrashInstances
+	{
+
+		public class CrashInstanceSet
+		{
+			private Dictionary<string, ICrashInstance> Instances { get; } = new();
+
+			public bool TryGetInstance<TInstance>(out TInstance instance) where TInstance : ICrashInstance
+			{
+				instance = default;
+				if (Instances.TryGetValue(typeof(TInstance).Name, out var crashInstance))
+				{
+					if (crashInstance is TInstance typedInstance)
+					{
+						instance = typedInstance;
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+			public bool SetInstance(ICrashInstance instance)
+			{
+				if (Instances.ContainsKey(instance.GetType().Name)) return false;
+				Instances.Add(instance.GetType().Name, instance);
+				return true;
+			}
+
+			public bool Remove(Type type)
+			{
+				return Instances.Remove(type.Name);
+			}
+
+		}
+
+		private static Dictionary<CrashDoc, CrashInstanceSet> Instances { get; } = new();
+
+		public static bool TryGetInstance<TInstance>(CrashDoc crashDoc, out TInstance instance) where TInstance : ICrashInstance
+		{
+			instance = default;
+			if (!Instances.TryGetValue(crashDoc, out CrashInstanceSet? instanceSet)) return false;
+			return instanceSet.TryGetInstance(out instance);
+		}
+
+		public static bool TrySetInstance<TInstance>(CrashDoc crashDoc, TInstance instance) where TInstance : ICrashInstance
+		{
+			if (!Instances.TryGetValue(crashDoc, out var instanceSet))
+			{
+				instanceSet = new CrashInstanceSet();
+				instanceSet.SetInstance(instance);
+				Instances.Add(crashDoc, instanceSet);
+			}
+			else
+			{
+				instanceSet.SetInstance(instance);
+			}
+
+			return true;
+		}
+
+		public static bool RemoveInstance(CrashDoc crashDoc, Type type)
+		{
+			if (!Instances.TryGetValue(crashDoc, out var instanceSet)) return false;
+			return instanceSet.Remove(type);
+		}
+
+		public static void DestroyInstance(CrashDoc crashDoc)
+		{
+			Instances.Remove(crashDoc);
+		}
+
+	}
+
+}

--- a/src/Crash.Common/Document/CrashDoc.cs
+++ b/src/Crash.Common/Document/CrashDoc.cs
@@ -12,14 +12,14 @@ namespace Crash.Common.Document
 	/// <summary>The Crash Document</summary>
 	public sealed class CrashDoc : IEquatable<CrashDoc>, IDisposable
 	{
-		private readonly Guid _id;
+		private Guid Id { get; }
 
 		#region constructors
 
 		/// <summary>Constructs a Crash Doc</summary>
 		public CrashDoc()
 		{
-			_id = Guid.NewGuid();
+			Id = Guid.NewGuid();
 
 			Users = new UserTable(this);
 			Tables = new CacheTable(this);
@@ -90,7 +90,7 @@ namespace Crash.Common.Document
 
 		public bool Equals(CrashDoc? other)
 		{
-			return other?.GetHashCode() == GetHashCode();
+			return other?.Id == Id;
 		}
 
 
@@ -102,7 +102,7 @@ namespace Crash.Common.Document
 
 		public override int GetHashCode()
 		{
-			return _id.GetHashCode();
+			return Id.GetHashCode();
 		}
 
 		#endregion

--- a/src/Crash.Common/Document/CrashDoc.cs
+++ b/src/Crash.Common/Document/CrashDoc.cs
@@ -93,12 +93,10 @@ namespace Crash.Common.Document
 			return other?.Id == Id;
 		}
 
-
 		public override bool Equals(object? obj)
 		{
 			return obj is CrashDoc other && Equals(other);
 		}
-
 
 		public override int GetHashCode()
 		{

--- a/src/Crash.Common/Tables/UserTable.cs
+++ b/src/Crash.Common/Tables/UserTable.cs
@@ -100,10 +100,10 @@ namespace Crash.Common.Tables
 		}
 
 		/// <summary>Fires each time a User is successfully added via Add</summary>
-		public static event EventHandler<UserEventArgs> OnUserAdded;
+		public event EventHandler<UserEventArgs> OnUserAdded;
 
 		/// <summary>Fires each time a User is successfuly removed via Remove</summary>
-		public static event EventHandler<UserEventArgs> OnUserRemoved;
+		public event EventHandler<UserEventArgs> OnUserRemoved;
 	}
 
 	public sealed class UserEventArgs : EventArgs

--- a/src/Crash.Handlers/CrashDocRegistry.cs
+++ b/src/Crash.Handlers/CrashDocRegistry.cs
@@ -106,7 +106,7 @@ namespace Crash.Handlers
 				double crashCount = e.Changes.Count();
 				double percentage = changeLoadAmount + (count / crashCount * changeLoadAmount);
 
-				LoadingUtils.SetState((LoadingUtils.LoadingState)(int)percentage, false);
+				LoadingUtils.SetState(itemArgs.CrashDoc, (LoadingUtils.LoadingState)(int)percentage, false);
 
 				if (count < crashCount) return;
 				e.CrashDoc.Queue.OnItemProcessed -= initialLoadingBar;

--- a/src/Crash.Handlers/Plugins/EventDispatcher.cs
+++ b/src/Crash.Handlers/Plugins/EventDispatcher.cs
@@ -43,7 +43,7 @@ namespace Crash.Handlers.Plugins
 			}
 		}
 
-		private async Task<List<Change>> TryGetChangeFromEvent(ChangeAction changeAction, object sender, EventArgs args)
+		internal async Task<List<Change>> TryGetChangeFromEvent(ChangeAction changeAction, object sender, EventArgs args)
 		{
 			if (!_createActions.TryGetValue(changeAction, out var actionChain))
 			{

--- a/src/Crash/Commands/JoinSharedModel.cs
+++ b/src/Crash/Commands/JoinSharedModel.cs
@@ -117,8 +117,6 @@ namespace Crash.Commands
 
 				await _crashDoc.Dispatcher.NotifyServerAsync(changes);
 
-				UsersForm.ShowForm(_crashDoc);
-
 				return;
 			}
 
@@ -132,7 +130,6 @@ namespace Crash.Commands
 		{
 			LoadingUtils.Close(_crashDoc);
 			e.CrashDoc.Queue.OnCompletedQueue -= QueueOnOnCompleted;
-			UsersForm.CloseActiveForm(e.CrashDoc);
 			UsersForm.ShowForm(e.CrashDoc);
 
 			StatusBar.HideProgressMeter();

--- a/src/Crash/Commands/JoinSharedModel.cs
+++ b/src/Crash/Commands/JoinSharedModel.cs
@@ -32,7 +32,6 @@ namespace Crash.Commands
 			Instance = this;
 		}
 
-
 		public static JoinSharedModel Instance { get; private set; }
 
 
@@ -139,7 +138,7 @@ namespace Crash.Commands
 		{
 			LoadingUtils.Close();
 			e.CrashDoc.Queue.OnCompletedQueue -= QueueOnOnCompleted;
-			UsersForm.CloseActiveForm();
+			UsersForm.CloseActiveForm(e.CrashDoc);
 			UsersForm.ShowForm(e.CrashDoc);
 
 			StatusBar.HideProgressMeter();

--- a/src/Crash/Commands/JoinSharedModel.cs
+++ b/src/Crash/Commands/JoinSharedModel.cs
@@ -26,16 +26,9 @@ namespace Crash.Commands
 		private string? _lastUrl = $"{CrashClient.DefaultURL}:{CrashClient.DefaultPort}";
 		private RhinoDoc _rhinoDoc;
 
-		/// <summary>Default Constructor</summary>
-		public JoinSharedModel()
-		{
-			Instance = this;
-		}
+		public override string EnglishName => EnglishCommandName;
 
-		public static JoinSharedModel Instance { get; private set; }
-
-
-		public override string EnglishName => "JoinSharedModel";
+		public const string EnglishCommandName = "JoinSharedModel";
 
 
 		protected override async Task<Result> RunCommandAsync(RhinoDoc doc, CrashDoc crashDoc, RunMode mode)
@@ -45,7 +38,7 @@ namespace Crash.Commands
 
 			if (crashDoc?.LocalClient?.IsConnected == true)
 			{
-				CommandUtils.AlertUser($"You are already connected to a model ({crashDoc.LocalClient.Url}). Please disconnect first.", mode == RunMode.Scripted);
+				CommandUtils.AlertUser(crashDoc, $"You are already connected to a model ({crashDoc.LocalClient.Url}). Please disconnect first.", mode == RunMode.Scripted);
 				return Result.Cancel;
 			}
 
@@ -69,13 +62,13 @@ namespace Crash.Commands
 			{
 				if (!CommandUtils.GetUserName(out name))
 				{
-					CommandUtils.AlertUser("Invalid Name Input. Avoid empty values", true);
+					CommandUtils.AlertUser(crashDoc, "Invalid Name Input. Avoid empty values", true);
 					return Result.Cancel;
 				}
 
 				if (!_GetServerURL(ref _lastUrl))
 				{
-					CommandUtils.AlertUser($"{_lastUrl} is an invalid URL.", true);
+					CommandUtils.AlertUser(crashDoc, $"{_lastUrl} is an invalid URL.", true);
 					return Result.Nothing;
 				}
 			}
@@ -92,7 +85,7 @@ namespace Crash.Commands
 
 		private async Task StartServer()
 		{
-			LoadingUtils.Start();
+			LoadingUtils.Start(_crashDoc);
 
 			var settings = new ObjectEnumeratorSettings
 			{
@@ -104,13 +97,14 @@ namespace Crash.Commands
 			};
 			var currentObjects = _rhinoDoc.Objects.GetObjectList(settings);
 
-			LoadingUtils.SetState(LoadingUtils.LoadingState.CheckingServer);
+			LoadingUtils.SetState(_crashDoc, LoadingUtils.LoadingState.CheckingServer);
 			_crashDoc.Queue.OnCompletedQueue += QueueOnOnCompleted;
 			if (await CommandUtils.StartLocalClient(_crashDoc, _lastUrl))
 			{
-				LoadingUtils.SetState(LoadingUtils.LoadingState.ConnectingToServer);
+				LoadingUtils.SetState(_crashDoc, LoadingUtils.LoadingState.ConnectingToServer);
 
-				InteractivePipe.Active.Enabled = true;
+				var pipe = InteractivePipe.GetActive(_crashDoc);
+				pipe.Enabled = true;
 
 				// Sends pre-existing Geometry
 				List<Change> changes = new List<Change>(currentObjects.Count());
@@ -131,12 +125,12 @@ namespace Crash.Commands
 			_crashDoc.Queue.OnCompletedQueue -= QueueOnOnCompleted;
 			await _crashDoc.LocalClient.StopAsync();
 
-			LoadingUtils.Close();
+			LoadingUtils.Close(_crashDoc);
 		}
 
 		private void QueueOnOnCompleted(object? sender, CrashEventArgs e)
 		{
-			LoadingUtils.Close();
+			LoadingUtils.Close(_crashDoc);
 			e.CrashDoc.Queue.OnCompletedQueue -= QueueOnOnCompleted;
 			UsersForm.CloseActiveForm(e.CrashDoc);
 			UsersForm.ShowForm(e.CrashDoc);

--- a/src/Crash/Commands/LeaveSharedModel.cs
+++ b/src/Crash/Commands/LeaveSharedModel.cs
@@ -15,17 +15,8 @@ namespace Crash.Commands
 	{
 		private bool defaultValue;
 
-		public LeaveSharedModel()
-		{
-			Instance = this;
-		}
-
-
-		public static LeaveSharedModel Instance { get; private set; }
-
-
-		public override string EnglishName => "LeaveSharedModel";
-
+		public override string EnglishName => EnglishCommandName;
+		public const string EnglishCommandName = "LeaveSharedModel";
 
 		protected override async Task<Result> RunCommandAsync(RhinoDoc doc, CrashDoc crashDoc, RunMode mode)
 		{
@@ -50,13 +41,14 @@ namespace Crash.Commands
 
 			(crashDoc.LocalClient as CrashClient).ClosedByUser = true;
 			await CrashDocRegistry.DisposeOfDocumentAsync(crashDoc);
-			InteractivePipe.Active.Enabled = false;
+			var pipe = InteractivePipe.GetActive(crashDoc);
+			pipe.Enabled = false;
 
 			RhinoApp.WriteLine("Model closed and saved successfully");
 
 			doc.Views.Redraw();
 			UsersForm.CloseActiveForm(crashDoc);
-			LoadingUtils.Close();
+			LoadingUtils.Close(crashDoc);
 
 			return Result.Success;
 		}

--- a/src/Crash/Commands/LeaveSharedModel.cs
+++ b/src/Crash/Commands/LeaveSharedModel.cs
@@ -55,7 +55,7 @@ namespace Crash.Commands
 			RhinoApp.WriteLine("Model closed and saved successfully");
 
 			doc.Views.Redraw();
-			UsersForm.CloseActiveForm();
+			UsersForm.CloseActiveForm(crashDoc);
 			LoadingUtils.Close();
 
 			return Result.Success;

--- a/src/Crash/Commands/Release.cs
+++ b/src/Crash/Commands/Release.cs
@@ -9,12 +9,6 @@ namespace Crash.Commands
 	[CommandStyle(Style.DoNotRepeat | Style.NotUndoable)]
 	public sealed class Release : AsyncCommand
 	{
-		public Release()
-		{
-			Instance = this;
-		}
-
-		public static Release Instance { get; private set; }
 
 		public override string EnglishName => "Release";
 

--- a/src/Crash/Commands/ReleaseSelected.cs
+++ b/src/Crash/Commands/ReleaseSelected.cs
@@ -12,15 +12,6 @@ namespace Crash.Commands
 	[CommandStyle(Style.DoNotRepeat | Style.NotUndoable)]
 	public sealed class ReleaseSelected : AsyncCommand
 	{
-		public ReleaseSelected()
-		{
-			Instance = this;
-		}
-
-
-		public static ReleaseSelected Instance { get; private set; }
-
-
 		public override string EnglishName => "ReleaseSelected";
 
 		protected override async Task<Result> RunCommandAsync(RhinoDoc doc, CrashDoc crashDoc, RunMode mode)

--- a/src/Crash/CrashRhinoPlugIn.cs
+++ b/src/Crash/CrashRhinoPlugIn.cs
@@ -24,17 +24,11 @@ namespace Crash
 		private const string CrashPluginId = "53CB2393-C71F-4079-9CEC-97464FF9D14E";
 
 		/// <summary>Contains all of the Change Definitions of this PlugIn</summary>
-		private static readonly Stack<IChangeDefinition> Changes;
+		private Stack<IChangeDefinition> Changes { get; set; }
 
 		#region Crash Plugin Specifics
 
-		static CrashRhinoPlugIn()
-		{
-			Changes = new Stack<IChangeDefinition>();
-			RhinoApp.Idle += LoadCrashPlugins;
-		}
-
-		private static void LoadCrashPlugins(object? sender, EventArgs e)
+		private void LoadCrashPlugins(object? sender, EventArgs e)
 		{
 			RhinoApp.Idle -= LoadCrashPlugins;
 
@@ -168,6 +162,8 @@ namespace Crash
 		{
 			Instance = this;
 
+			Changes = new Stack<IChangeDefinition>();
+
 			// Register the Defaults!
 			Changes.Push(new GeometryChangeDefinition());
 			Changes.Push(new CameraChangeDefinition());
@@ -191,6 +187,8 @@ namespace Crash
 			InteractivePipe.Active = new InteractivePipe { Enabled = false };
 
 			CrashApp.UserMessage += (_, m) => RhinoApp.WriteLine(m);
+
+			RhinoApp.Idle += LoadCrashPlugins;
 
 			return base.OnLoad(ref errorMessage);
 		}

--- a/src/Crash/CrashRhinoPlugIn.cs
+++ b/src/Crash/CrashRhinoPlugIn.cs
@@ -14,6 +14,7 @@ using Eto.Forms;
 
 using Rhino.PlugIns;
 using Crash.Common.App;
+using Crash.Common.Document;
 
 namespace Crash
 {
@@ -54,8 +55,9 @@ namespace Crash
 			var dispatcher = e.CrashDoc.Dispatcher as EventDispatcher;
 			dispatcher?.DeregisterDefaultServerCalls();
 			e.CrashDoc.Dispatcher = null;
-			InteractivePipe.Active.Enabled = false;
-			InteractivePipe.ClearChangeDefinitions();
+			var pipe = InteractivePipe.GetActive(e.CrashDoc);
+			pipe.Enabled = false;
+			pipe.ClearChangeDefinitions();
 		}
 
 		private void CrashDocRegistryOnDocumentRegistered(object? sender, CrashEventArgs e)
@@ -63,10 +65,11 @@ namespace Crash
 			var dispatcher = new EventDispatcher(e.CrashDoc);
 			dispatcher.RegisterDefaultServerNotifiers();
 			dispatcher.RegisterDefaultServerCalls(e.CrashDoc);
-			RegisterDefinitions(dispatcher);
+			RegisterDefinitions(e.CrashDoc, dispatcher);
 			e.CrashDoc.Dispatcher = dispatcher;
 			RegisterExceptions(e.CrashDoc.LocalClient as CrashClient);
-			InteractivePipe.Active.Enabled = true;
+			var pipe = InteractivePipe.GetActive(e.CrashDoc);
+			pipe.Enabled = true;
 			badPipe = new BadChangePipeline(e.CrashDoc);
 		}
 
@@ -93,14 +96,14 @@ namespace Crash
 			{
 				Title = "Changes failed to send!",
 				Message = "Any changes highlighted in red will not be communicated\n" +
-											   "It is advised to delete them.\n" +
-											   "It may be because the Change is > 1Mb."
+												 "It is advised to delete them.\n" +
+												 "It may be because the Change is > 1Mb."
 			};
 
 			RhinoApp.InvokeOnUiThread(() =>
-									  {
-										  badChangeToast.Show();
-									  });
+										{
+											badChangeToast.Show();
+										});
 		}
 
 #pragma warning disable VSTHRD100 // Avoid async void methods
@@ -108,15 +111,15 @@ namespace Crash
 
 		{
 			var message = "The server connection has been lost.\n" +
-						  "Your model will be closed.\n" +
-						  "Objects highlighted in Red have not transmitted all of their data and will be lost.";
+							"Your model will be closed.\n" +
+							"Objects highlighted in Red have not transmitted all of their data and will be lost.";
 			try
 			{
 				RhinoApp.InvokeOnUiThread(() =>
-										  {
-											  MessageBox.Show(message, MessageBoxButtons.OK);
-											  UsersForm.CloseActiveForm(args.CrashDoc);
-										  });
+											{
+												MessageBox.Show(message, MessageBoxButtons.OK);
+												UsersForm.CloseActiveForm(args.CrashDoc);
+											});
 
 				var rhinoDoc = CrashDocRegistry.GetRelatedDocument(args.CrashDoc);
 				await CrashDocRegistry.DisposeOfDocumentAsync(args.CrashDoc);
@@ -129,7 +132,7 @@ namespace Crash
 		}
 #pragma warning restore VSTHRD100 // Avoid async void methods
 
-		private void RegisterDefinitions(EventDispatcher dispatcher)
+		private void RegisterDefinitions(CrashDoc crashDoc, EventDispatcher dispatcher)
 		{
 			var changeEnuner = Changes.GetEnumerator();
 
@@ -137,7 +140,10 @@ namespace Crash
 			{
 				var changeDefinition = changeEnuner.Current;
 				dispatcher.RegisterDefinition(changeDefinition);
-				InteractivePipe.RegisterChangeDefinition(changeDefinition);
+
+				var pipe = InteractivePipe.GetActive(crashDoc);
+				pipe.Enabled = true;
+				pipe.RegisterChangeDefinition(changeDefinition);
 			}
 		}
 
@@ -183,9 +189,6 @@ namespace Crash
 
 		protected override LoadReturnCode OnLoad(ref string errorMessage)
 		{
-			// Add feature flags as advanced settings here!
-			InteractivePipe.Active = new InteractivePipe { Enabled = false };
-
 			CrashApp.UserMessage += (_, m) => RhinoApp.WriteLine(m);
 
 			RhinoApp.Idle += LoadCrashPlugins;

--- a/src/Crash/CrashRhinoPlugIn.cs
+++ b/src/Crash/CrashRhinoPlugIn.cs
@@ -121,7 +121,7 @@ namespace Crash
 				RhinoApp.InvokeOnUiThread(() =>
 										  {
 											  MessageBox.Show(message, MessageBoxButtons.OK);
-											  UsersForm.CloseActiveForm();
+											  UsersForm.CloseActiveForm(args.CrashDoc);
 										  });
 
 				var rhinoDoc = CrashDocRegistry.GetRelatedDocument(args.CrashDoc);

--- a/src/Crash/UI/InteractivePipe.cs
+++ b/src/Crash/UI/InteractivePipe.cs
@@ -1,5 +1,6 @@
 ﻿using System.Drawing;
 
+using Crash.Common.App;
 using Crash.Common.Changes;
 using Crash.Common.Document;
 using Crash.Common.Tables;
@@ -14,16 +15,20 @@ namespace Crash.UI
 	/// <summary>
 	///     Interactive pipeline for crash geometry display
 	/// </summary>
-	// TODO : Make this static, and turn it into a template that just
-	// grabs things from the CrashDoc
-	// There's no need to recreate the same class again and again
-	// and store so much geometry.
-	internal sealed class InteractivePipe : IDisposable
+	internal sealed class InteractivePipe : ICrashInstance
 	{
-		private static readonly Dictionary<string, IChangeDefinition> definitionRegistry;
+		private readonly Dictionary<string, IChangeDefinition> definitionRegistry;
 
-
-		internal static InteractivePipe Active;
+		internal static InteractivePipe GetActive(CrashDoc crashDoc)
+		{
+			CrashInstances.TryGetInstance(crashDoc, out InteractivePipe activePipe);
+			if (activePipe is null)
+			{
+				activePipe = new InteractivePipe(crashDoc);
+				CrashInstances.TrySetInstance(crashDoc, activePipe);
+			}
+			return activePipe;
+		}
 
 		private readonly DisplayMaterial cachedMaterial = new(Color.Blue);
 
@@ -31,18 +36,14 @@ namespace Crash.UI
 		// TODO : Don't draw things not in the view port
 		private BoundingBox bbox;
 
-		static InteractivePipe()
-		{
-			definitionRegistry = new Dictionary<string, IChangeDefinition>();
-		}
-
 		/// <summary>
 		///     Empty constructor
 		/// </summary>
-		internal InteractivePipe()
+		internal InteractivePipe(CrashDoc crashDoc)
 		{
 			bbox = new BoundingBox(-100, -100, -100, 100, 100, 100);
-			Active = this;
+			CrashInstances.TrySetInstance(crashDoc, this);
+			definitionRegistry = new Dictionary<string, IChangeDefinition>();
 		}
 
 		private bool enabled { get; set; }
@@ -75,10 +76,6 @@ namespace Crash.UI
 			}
 		}
 
-		public void Dispose()
-		{
-		}
-
 		/// <summary>
 		///     Method to calculate the bounding box
 		/// </summary>
@@ -108,7 +105,8 @@ namespace Crash.UI
 			}
 
 			var caches = tempTable.GetChanges().ToList();
-			foreach (var change in caches)
+			var orderedCaches = caches.OrderBy(c => c.Owner);
+			foreach (var change in orderedCaches)
 			{
 				if (e.Display.InterruptDrawing())
 				{
@@ -190,12 +188,12 @@ namespace Crash.UI
 			bbox.Union(changeBox);
 		}
 
-		internal static void RegisterChangeDefinition(IChangeDefinition changeDefinition)
+		internal void RegisterChangeDefinition(IChangeDefinition changeDefinition)
 		{
 			definitionRegistry.Add(changeDefinition.ChangeName, changeDefinition);
 		}
 
-		public static void ClearChangeDefinitions()
+		public void ClearChangeDefinitions()
 		{
 			definitionRegistry.Clear();
 		}

--- a/src/Crash/UI/JoinView/JoinWindow.cs
+++ b/src/Crash/UI/JoinView/JoinWindow.cs
@@ -41,7 +41,6 @@ namespace Crash.UI.JoinModel
 		internal string ChosenAddress { get; set; }
 
 		private JoinViewModel? Model => DataContext as JoinViewModel;
-		protected static bool IsOSX => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
 		private event EventHandler<EventArgs> AddNewModel;
 		private event EventHandler<EventArgs> RemoveModel;

--- a/src/Crash/UI/JoinView/JoinWindow.cs
+++ b/src/Crash/UI/JoinView/JoinWindow.cs
@@ -10,9 +10,6 @@ namespace Crash.UI.JoinModel
 {
 	public partial class JoinWindow : Dialog<SharedModel>, IDisposable
 	{
-		// internal JoinViewModel ViewModel { get; set; }
-
-		internal static JoinWindow ActiveForm;
 
 		internal JoinWindow()
 		{
@@ -31,9 +28,8 @@ namespace Crash.UI.JoinModel
 			SubscribeToEvents();
 			try
 			{
-				Model = new JoinViewModel();
+				DataContext = new JoinViewModel();
 				InitializeComponent();
-				ActiveForm = this;
 				Closed += JoinWindow_Closed;
 			}
 			catch
@@ -44,7 +40,7 @@ namespace Crash.UI.JoinModel
 
 		internal string ChosenAddress { get; set; }
 
-		private JoinViewModel Model { get; }
+		private JoinViewModel? Model => DataContext as JoinViewModel;
 		protected static bool IsOSX => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
 		private event EventHandler<EventArgs> AddNewModel;
@@ -53,7 +49,7 @@ namespace Crash.UI.JoinModel
 
 		private void JoinWindow_Closed(object? sender, EventArgs e)
 		{
-			Model.SaveSharedModels(null, null);
+			Model?.SaveSharedModels(null, null);
 		}
 
 		private void SubscribeToEvents()

--- a/src/Crash/UI/UsersView/UsersView.cs
+++ b/src/Crash/UI/UsersView/UsersView.cs
@@ -41,8 +41,8 @@ namespace Crash.UI.UsersView
 
 		protected override void OnShown(EventArgs e)
 		{
-			if (!CrashInstances.TryGetInstance<UsersForm>(_crashDoc, out var usersForm)) return;
-			CrashInstances.TrySetInstance(_crashDoc, this);
+			if (!CrashInstances.TryGetInstance<UsersForm>(_crashDoc, out var usersForm))
+				CrashInstances.TrySetInstance(_crashDoc, this);
 
 			base.OnShown(e);
 		}
@@ -54,6 +54,7 @@ namespace Crash.UI.UsersView
 			{
 				usersForm = new UsersForm(crashDoc);
 				var rhinoDoc = CrashDocRegistry.GetRelatedDocument(crashDoc);
+				CrashInstances.TrySetInstance(crashDoc, usersForm);
 				usersForm.Show(rhinoDoc);
 			}
 

--- a/src/Crash/UI/UsersView/UsersViewModel.cs
+++ b/src/Crash/UI/UsersView/UsersViewModel.cs
@@ -19,7 +19,7 @@ namespace Crash.UI.UsersView
 			var userObjects = _crashDoc.Users.Where(u => !string.IsNullOrEmpty(u.Name)).Select(u =>
 						 {
 							 var user = new UserObject(_crashDoc, u);
-							 user.OnPropertyChanged += (sender, o) => UsersForm.ReDraw();
+							 user.OnPropertyChanged += (sender, o) => UsersForm.ReDraw(crashDoc);
 							 return user;
 						 });
 			Users = new ObservableCollection<UserObject> { UserObject.CreateForCurrentUser(_crashDoc) };
@@ -43,7 +43,7 @@ namespace Crash.UI.UsersView
 			Application.Instance.Invoke(() =>
 										{
 											Users.Add(new UserObject(_crashDoc, e.User));
-											UsersForm.ReDraw();
+											UsersForm.ReDraw(_crashDoc);
 										});
 		}
 
@@ -52,7 +52,7 @@ namespace Crash.UI.UsersView
 			Application.Instance.Invoke(() =>
 										{
 											Users.Remove(new UserObject(_crashDoc, e.User));
-											UsersForm.ReDraw();
+											UsersForm.ReDraw(_crashDoc);
 										});
 		}
 
@@ -94,7 +94,7 @@ namespace Crash.UI.UsersView
 			var index = Users.IndexOf(user);
 			Users.RemoveAt(index);
 			Users.Insert(index, user);
-			UsersForm.ReDraw();
+			UsersForm.ReDraw(_crashDoc);
 		}
 
 		private static CameraState CycleState(CameraState state)

--- a/src/Crash/UI/UsersView/UsersViewModel.cs
+++ b/src/Crash/UI/UsersView/UsersViewModel.cs
@@ -27,8 +27,8 @@ namespace Crash.UI.UsersView
 			foreach (var userObject in userObjects)
 				Users.Add(userObject);
 
-			UserTable.OnUserRemoved += UserRemoved;
-			UserTable.OnUserAdded += AddUsers;
+			crashDoc.Users.OnUserRemoved += UserRemoved;
+			crashDoc.Users.OnUserAdded += AddUsers;
 		}
 
 		internal ObservableCollection<UserObject> Users { get; set; }

--- a/tests/Crash.Common.Tests/Tables.cs/UserTableTests.cs
+++ b/tests/Crash.Common.Tests/Tables.cs/UserTableTests.cs
@@ -66,7 +66,7 @@ namespace Crash.Common.Tests.Tables
 			var userTable = new UserTable(crashDoc);
 			var user = new User("user1");
 			var eventRaised = false;
-			UserTable.OnUserAdded += (sender, args) => eventRaised = true;
+			userTable.OnUserAdded += (sender, args) => eventRaised = true;
 
 			// Act
 			var result = userTable.Add(user);
@@ -107,7 +107,7 @@ namespace Crash.Common.Tests.Tables
 			var user = new User("user1");
 			userTable.Add(user);
 			var eventRaised = false;
-			UserTable.OnUserRemoved += (sender, args) => eventRaised = true;
+			userTable.OnUserRemoved += (sender, args) => eventRaised = true;
 
 			// Act
 			userTable.Remove(user);

--- a/tests/Crash.Handlers.Tests/Plugins/EventDispatcherTests.cs
+++ b/tests/Crash.Handlers.Tests/Plugins/EventDispatcherTests.cs
@@ -128,6 +128,8 @@ namespace Crash.Handlers.Tests.Plugins
 													   { nameof(ICrashClient.OnInitializeUsers), 0 }
 												   };
 
+		public string Url { get; }
+
 		internal DispatcherTestClient()
 		{
 			// On InitialiseChanges
@@ -148,10 +150,11 @@ namespace Crash.Handlers.Tests.Plugins
 			await Task.CompletedTask;
 		}
 
-		public async Task StartLocalClientAsync()
+		public async Task<Exception?> StartLocalClientAsync()
 		{
 			IncrementCallCount(nameof(ICrashClient.StartLocalClientAsync));
 			await Task.CompletedTask;
+			return null;
 		}
 
 		public async Task StreamChangesAsync(IAsyncEnumerable<Change> changes)

--- a/tests/Crash.Handlers.Tests/Plugins/EventDispatcherTests.cs
+++ b/tests/Crash.Handlers.Tests/Plugins/EventDispatcherTests.cs
@@ -123,12 +123,7 @@ namespace Crash.Handlers.Tests.Plugins
 												   {
 													   { nameof(ICrashClient.StopAsync), 0 },
 													   { nameof(ICrashClient.StartLocalClientAsync), 0 },
-													   { nameof(ICrashClient.PushIdenticalChangesAsync), 0 },
-													   { nameof(ICrashClient.PushChangeAsync), 0 },
-													   { nameof(ICrashClient.PushChangesAsync), 0 },
-													   { nameof(ICrashClient.OnRecieveIdentical), 0 },
-													   { nameof(ICrashClient.OnRecieveChange), 0 },
-													   { nameof(ICrashClient.OnRecieveChanges), 0 },
+													   { nameof(ICrashClient.StreamChangesAsync), 0 },
 													   { nameof(ICrashClient.OnInitializeChanges), 0 },
 													   { nameof(ICrashClient.OnInitializeUsers), 0 }
 												   };
@@ -159,21 +154,9 @@ namespace Crash.Handlers.Tests.Plugins
 			await Task.CompletedTask;
 		}
 
-		public async Task PushIdenticalChangesAsync(IEnumerable<Guid> ids, Change change)
+		public async Task StreamChangesAsync(IAsyncEnumerable<Change> changes)
 		{
-			IncrementCallCount(nameof(ICrashClient.PushIdenticalChangesAsync));
-			await Task.CompletedTask;
-		}
-
-		public async Task PushChangeAsync(Change change)
-		{
-			IncrementCallCount(nameof(ICrashClient.PushChangeAsync));
-			await Task.CompletedTask;
-		}
-
-		public async Task PushChangesAsync(IEnumerable<Change> changes)
-		{
-			IncrementCallCount(nameof(ICrashClient.PushChangesAsync));
+			IncrementCallCount(nameof(ICrashClient.StreamChangesAsync));
 			await Task.CompletedTask;
 		}
 

--- a/tests/Crash.Handlers.Tests/Plugins/EventDispatcherTests.cs
+++ b/tests/Crash.Handlers.Tests/Plugins/EventDispatcherTests.cs
@@ -32,26 +32,26 @@ namespace Crash.Handlers.Tests.Plugins
 				var addArgs = new CrashObjectEventArgs(null, point, rhinoId, Guid.NewGuid());
 				yield return new object[]
 							 {
-								 nameof(ICrashClient.PushChangeAsync), ChangeAction.Add | ChangeAction.Temporary,
+								 nameof(ICrashClient.StreamChangesAsync), ChangeAction.Add | ChangeAction.Temporary,
 								 addArgs
 							 };
 
 				var deleteArgs = new CrashObjectEventArgs(null, null, Guid.NewGuid(), Guid.NewGuid());
-				yield return new object[] { nameof(ICrashClient.PushChangeAsync), ChangeAction.Remove, deleteArgs };
+				yield return new object[] { nameof(ICrashClient.StreamChangesAsync), ChangeAction.Remove, deleteArgs };
 
 				var crashObject = new CrashObject(Guid.NewGuid(), Guid.NewGuid());
 				var selectArgs = CrashSelectionEventArgs.CreateSelectionEvent(null, new[] { crashObject });
-				yield return new object[] { nameof(ICrashClient.PushChangeAsync), ChangeAction.Locked, selectArgs };
+				yield return new object[] { nameof(ICrashClient.StreamChangesAsync), ChangeAction.Locked, selectArgs };
 
 
 				var deSelectArgs = CrashSelectionEventArgs.CreateDeSelectionEvent(null, new[] { crashObject });
-				yield return new object[] { nameof(ICrashClient.PushChangeAsync), ChangeAction.Unlocked, deSelectArgs };
+				yield return new object[] { nameof(ICrashClient.StreamChangesAsync), ChangeAction.Unlocked, deSelectArgs };
 
 				// Where do Transforms go?
 				// nameof(ICrashClient)
 
 				//
-				yield return new object[] { nameof(ICrashClient.PushChangeAsync), ChangeAction.Update, null };
+				yield return new object[] { nameof(ICrashClient.StreamChangesAsync), ChangeAction.Update, null };
 
 				/*
 				var args = EventArgs.Empty;
@@ -106,7 +106,8 @@ namespace Crash.Handlers.Tests.Plugins
 		[TestCaseSource(nameof(DispatchEvents))]
 		public async Task TestAddDispatch(string callName, ChangeAction action, EventArgs args)
 		{
-			await eventDispatcher.NotifyServerAsync(action, this, args);
+			var changes = await eventDispatcher.TryGetChangeFromEvent(action, this, args);
+			await eventDispatcher.NotifyServerAsync(changes);
 			AssertCallCount(callName, 1);
 		}
 

--- a/tests/Crash.Handlers.Tests/Plugins/Geometry/GeometryAddRecieveActionTests.cs
+++ b/tests/Crash.Handlers.Tests/Plugins/Geometry/GeometryAddRecieveActionTests.cs
@@ -2,6 +2,7 @@
 
 using Crash.Changes;
 using Crash.Common.Document;
+using Crash.Common.Tables;
 using Crash.Handlers.Changes;
 using Crash.Handlers.Plugins.Geometry.Recieve;
 

--- a/tests/Crash.Handlers.Tests/Plugins/Geometry/GeometryCreateRemoveActionTests.cs
+++ b/tests/Crash.Handlers.Tests/Plugins/Geometry/GeometryCreateRemoveActionTests.cs
@@ -2,6 +2,7 @@
 
 using Crash.Changes;
 using Crash.Common.Document;
+using Crash.Common.Tables;
 using Crash.Handlers.Changes;
 using Crash.Handlers.InternalEvents;
 using Crash.Handlers.Plugins;
@@ -104,7 +105,7 @@ namespace Crash.Handlers.Tests.Plugins
 			var cache = GeometryChange.CreateNew(createRecieveArgs.Geometry, "Test");
 			cache.Id = createRecieveArgs.ChangeId;
 
-			Assert.True(_cdoc.Tables.TryGetTable<TemporaryChangeTable>(out var table));
+			Assert.That(_cdoc.Tables.TryGet<TemporaryChangeTable>(out var table), Is.True);
 			table.UpdateChange(cache);
 
 			Assert.That(createAction.TryConvert(null, createArgs, out var changes), Is.True);


### PR DESCRIPTION
# Description

Statics fall on their ass completely when a 2nd document exists on Mac.
This PR Removes statics and creates `CrashInstances`.

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the docs
- [ ] My changes generate no new warnings
